### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   smoke-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/RF1705/youtube-webos-cobalt-adfree/security/code-scanning/1](https://github.com/RF1705/youtube-webos-cobalt-adfree/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (best here since there is one job and no need for per-job differences).  
Use least privilege: `contents: read` is sufficient for `actions/checkout` and for the rest of the shown steps.

**Where to change:** `.github/workflows/ci.yml`, immediately after the trigger section (`on:` block) and before `jobs:`.

**What to add:**  
```yml
permissions:
  contents: read
```

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
