### PR TITLE
Fix ads between Shorts and release v1.1.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PACKAGE_NAME_OFFICIAL=youtube.leanback.v4
 PACKAGE_NAME?=youtube.leanback.v4
 PACKAGE_NAME_TARGET=$(PACKAGE_NAME)
 PACKAGE_DISPLAY_NAME?=YouTube webOS Cobalt AdFree
-PROJECT_VERSION?=1.1.2
+PROJECT_VERSION?=1.1.3
 PACKAGE_COBALT_VERSION?=23.lts.4
 PACKAGE_VERSION?=$(PROJECT_VERSION)
 PACKAGE_IPK_BUILD=$(PACKAGE_NAME_TARGET)_$(PACKAGE_VERSION)_arm.ipk
@@ -32,7 +32,7 @@ COMPAT_TEST_OFFICIAL_YOUTUBE_IPK?=ipks-official/2022-12-01-youtube.leanback.v4-1
 COMPAT_TEST_PACKAGE_NAME?=com.cobalt.youtube.adfree.compat
 COMPAT_TEST_DISPLAY_NAME?=YouTube Cobalt AdFree Compatibility Test
 # webOS requires versions in strictly numeric major.minor.patch form.
-COMPAT_TEST_VERSION?=1.1.2
+COMPAT_TEST_VERSION?=1.1.3
 
 WORKDIR?=workdir
 WORKDIR_COBALT?=$(WORKDIR)/cobalt-$(BUILD_COBALT_VERSION)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project patches the webOS YouTube application by replacing or modifying the
 
 > This project is unofficial and is not affiliated with YouTube, Google, LG or webOS.
 
-## v1.1.2
+## v1.1.3
 
 The latest release is available from the GitHub releases page:
 
@@ -64,7 +64,7 @@ Download a release `.ipk` package and install it using one of the following meth
 Recommended release package:
 
 ```text
-youtube.leanback.v4_1.1.2_arm.ipk
+youtube.leanback.v4_1.1.3_arm.ipk
 ```
 
 The release also contains `youtube.leanback.v4.manifest.json` for installation
@@ -104,14 +104,14 @@ the webOS app install service:
 ```sh
 mkdir -p /media/developer/temp
 cd /media/developer/temp
-wget https://github.com/RF1705/youtube-webos-cobalt-adfree/releases/download/v1.1.2/youtube.leanback.v4_1.1.2_arm.ipk
-luna-send-pub -i 'luna://com.webos.appInstallService/dev/install' '{"id":"com.ares.defaultName","ipkUrl":"/media/developer/temp/youtube.leanback.v4_1.1.2_arm.ipk","subscribe":true}'
+wget https://github.com/RF1705/youtube-webos-cobalt-adfree/releases/download/v1.1.3/youtube.leanback.v4_1.1.3_arm.ipk
+luna-send-pub -i 'luna://com.webos.appInstallService/dev/install' '{"id":"com.ares.defaultName","ipkUrl":"/media/developer/temp/youtube.leanback.v4_1.1.3_arm.ipk","subscribe":true}'
 ```
 
 After installation, the downloaded package can be removed:
 
 ```sh
-rm /media/developer/temp/youtube.leanback.v4_1.1.2_arm.ipk
+rm /media/developer/temp/youtube.leanback.v4_1.1.3_arm.ipk
 ```
 
 ## Patch an official YouTube IPK

--- a/docs/release-v1.1.3.md
+++ b/docs/release-v1.1.3.md
@@ -1,0 +1,21 @@
+# v1.1.3
+
+This maintenance release fixes advertisements appearing while scrolling
+between videos in the YouTube Shorts reel.
+
+## Fixed
+
+- Shorts entries marked with YouTube's newer `REEL_VIDEO_TYPE_AD` schema are
+  now removed before the reel is rendered.
+- Advertisement markers are recognized across the known command, navigation,
+  reel item and tile endpoint layouts.
+- The string value `"false"` is no longer treated as an advertisement marker.
+
+The updated detection follows the schema used by the current NicholasBly
+YouTube webOS fork while keeping the existing recursive response filtering.
+
+Thanks to [TheKnight-Dev](https://github.com/TheKnight-Dev) for reporting the
+problem in [issue #8](https://github.com/RF1705/youtube-webos-cobalt-adfree/issues/8).
+
+Install `youtube.leanback.v4_1.1.3_arm.ipk` directly or use the custom Homebrew
+Channel repository listed in the README.

--- a/repo.json
+++ b/repo.json
@@ -7,17 +7,17 @@
       "iconUri": "https://raw.githubusercontent.com/RF1705/youtube-webos-cobalt-adfree/main/assets/largeIcon.png",
       "manifest": {
         "id": "youtube.leanback.v4",
-        "version": "1.1.2",
+        "version": "1.1.3",
         "type": "native",
         "title": "YouTube Cobalt AdFree",
         "iconUri": "https://raw.githubusercontent.com/RF1705/youtube-webos-cobalt-adfree/main/assets/largeIcon.png",
         "sourceUrl": "https://github.com/RF1705/youtube-webos-cobalt-adfree",
         "rootRequired": false,
-        "ipkUrl": "https://github.com/RF1705/youtube-webos-cobalt-adfree/releases/download/v1.1.2/youtube.leanback.v4_1.1.2_arm.ipk",
+        "ipkUrl": "https://github.com/RF1705/youtube-webos-cobalt-adfree/releases/download/v1.1.3/youtube.leanback.v4_1.1.3_arm.ipk",
         "ipkHash": {
-          "sha256": "80451e0ef1a4a68ffe6e046d1fdc72d0ebbca05cb9307c5a7665df04a75881ca"
+          "sha256": "94b9c22ad349ba000a8b826c7eeac5f189d9b5c296315daf05891909f02d2f01"
         },
-        "ipkSize": 20262680
+        "ipkSize": 20262846
       }
     }
   ]

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -14,6 +14,8 @@ const AD_KEYS = [
   'playerAds'
 ];
 
+const REEL_AD_VIDEO_TYPE = 'REEL_VIDEO_TYPE_AD';
+
 function stripYouTubeAds(value, depth = 0) {
   if (!value || typeof value !== 'object' || depth > 8) return false;
 
@@ -41,12 +43,29 @@ function stripYouTubeAds(value, depth = 0) {
 }
 
 function isAdditionalAdEntry(value) {
-  return Boolean(
-    value &&
-      typeof value === 'object' &&
-      (Object.prototype.hasOwnProperty.call(value, 'adSlotRenderer') ||
-        value.command?.reelWatchEndpoint?.adClientParams?.isAd)
-  );
+  if (!value || typeof value !== 'object') return false;
+
+  if (Object.prototype.hasOwnProperty.call(value, 'adSlotRenderer')) {
+    return true;
+  }
+
+  const reelEndpoints = [
+    value.command?.reelWatchEndpoint,
+    value.onSelectCommand?.reelWatchEndpoint,
+    value.navigationEndpoint?.reelWatchEndpoint,
+    value.reelItemRenderer?.navigationEndpoint?.reelWatchEndpoint,
+    value.tileRenderer?.onSelectCommand?.reelWatchEndpoint
+  ];
+
+  return reelEndpoints.some((endpoint) => {
+    const isAd = endpoint?.adClientParams?.isAd;
+
+    return (
+      isAd === true ||
+      isAd === 'true' ||
+      endpoint?.videoType === REEL_AD_VIDEO_TYPE
+    );
+  });
 }
 
 // YouTube changes the nesting of browse and Shorts responses frequently. Remove

--- a/youtube.leanback.v4.manifest.json
+++ b/youtube.leanback.v4.manifest.json
@@ -1,13 +1,13 @@
 {
   "id": "youtube.leanback.v4",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "native",
   "title": "YouTube Cobalt AdFree",
   "iconUri": "https://raw.githubusercontent.com/RF1705/youtube-webos-cobalt-adfree/main/assets/largeIcon.png",
   "sourceUrl": "https://github.com/RF1705/youtube-webos-cobalt-adfree",
   "rootRequired": false,
-  "ipkUrl": "youtube.leanback.v4_1.1.2_arm.ipk",
+  "ipkUrl": "youtube.leanback.v4_1.1.3_arm.ipk",
   "ipkHash": {
-    "sha256": "80451e0ef1a4a68ffe6e046d1fdc72d0ebbca05cb9307c5a7665df04a75881ca"
+    "sha256": "94b9c22ad349ba000a8b826c7eeac5f189d9b5c296315daf05891909f02d2f01"
   }
 }


### PR DESCRIPTION
## What changed

- recognize Shorts ads marked with `REEL_VIDEO_TYPE_AD`
- cover known command, navigation, reel-item, and tile endpoint layouts
- avoid treating the string `"false"` as an ad marker
- bump the app and compatibility package versions to 1.1.3
- update release notes, README, manifest hash, and Homebrew repository metadata

## Root cause

The existing filter handled `adSlotRenderer` and `adClientParams.isAd`, but
newer YouTube Shorts responses can identify reel advertisements only through
`videoType: "REEL_VIDEO_TYPE_AD"`. Those entries therefore remained in the
Shorts sequence.

## Validation

- production webapp build completed successfully
- ESLint passed
- targeted filtering smoke test passed
- packaged IPK reports `youtube.leanback.v4` version `1.1.3`
- packaged bundle contains the `REEL_VIDEO_TYPE_AD` detector
- manifest JSON and SHA-256 metadata validated

Fixes #8.
