### PR TITLE
Add experimental multi-starter IPK build

### DIFF
--- a/Makefile.multistarter
+++ b/Makefile.multistarter
@@ -13,8 +13,6 @@ MULTISTARTER_DEFAULT?=auto
 MULTISTARTER_SB13_COBALT_ARCHIVE?=$(or $(wildcard cobalt-bin/23.lts.6-13.xz),$(PRIVATE_IMAGES_DIR)/cobalt-bin/23.lts.6-13.xz)
 MULTISTARTER_SB14_ALIAS?=$(PRIVATE_IMAGES_DIR)/starters/by-starboard/sb14.path
 MULTISTARTER_SB16_ALIAS?=$(PRIVATE_IMAGES_DIR)/starters/by-starboard/sb16.path
-MULTISTARTER_SB14_STARTER?=$(PRIVATE_IMAGES_DIR)/$(shell cat "$(MULTISTARTER_SB14_ALIAS)" 2>/dev/null)
-MULTISTARTER_SB16_STARTER?=$(PRIVATE_IMAGES_DIR)/$(shell cat "$(MULTISTARTER_SB16_ALIAS)" 2>/dev/null)
 
 MULTISTARTER_IPK=$(PACKAGE_OUTPUT_DIR)/$(PACKAGE_NAME)_$(MULTISTARTER_VERSION)_arm.ipk
 MULTISTARTER_BUILT_IPK=$(WORKDIR)/ipk-output/$(PACKAGE_NAME)_$(MULTISTARTER_VERSION)_arm.ipk
@@ -32,12 +30,15 @@ MULTISTARTER_MAKE_ARGS=\
 
 .PHONY: multistarter-check
 multistarter-check: images
-	@test -f "$(MULTISTARTER_SB13_COBALT_ARCHIVE)" || (echo "Missing Starboard 13 Cobalt archive: $(MULTISTARTER_SB13_COBALT_ARCHIVE)" && exit 1)
-	@test -f "$(MULTISTARTER_SB14_ALIAS)" || (echo "Missing Starboard 14 alias: $(MULTISTARTER_SB14_ALIAS)" && exit 1)
-	@test -f "$(MULTISTARTER_SB16_ALIAS)" || (echo "Missing Starboard 16 alias: $(MULTISTARTER_SB16_ALIAS)" && exit 1)
-	@test -f "$(MULTISTARTER_SB14_STARTER)" || (echo "Missing Starboard 14 starter resolved from $(MULTISTARTER_SB14_ALIAS): $(MULTISTARTER_SB14_STARTER)" && exit 1)
-	@test -f "$(MULTISTARTER_SB16_STARTER)" || (echo "Missing Starboard 16 starter resolved from $(MULTISTARTER_SB16_ALIAS): $(MULTISTARTER_SB16_STARTER)" && exit 1)
-	@case "$(MULTISTARTER_DEFAULT)" in auto|sb13|sb14|sb16) ;; *) echo "MULTISTARTER_DEFAULT must be auto, sb13, sb14 or sb16"; exit 1;; esac
+	@set -eu; \
+	test -f "$(MULTISTARTER_SB13_COBALT_ARCHIVE)" || { echo "Missing Starboard 13 Cobalt archive: $(MULTISTARTER_SB13_COBALT_ARCHIVE)"; exit 1; }; \
+	test -f "$(MULTISTARTER_SB14_ALIAS)" || { echo "Missing Starboard 14 alias: $(MULTISTARTER_SB14_ALIAS)"; exit 1; }; \
+	test -f "$(MULTISTARTER_SB16_ALIAS)" || { echo "Missing Starboard 16 alias: $(MULTISTARTER_SB16_ALIAS)"; exit 1; }; \
+	sb14="$(PRIVATE_IMAGES_DIR)/$$(cat "$(MULTISTARTER_SB14_ALIAS)")"; \
+	sb16="$(PRIVATE_IMAGES_DIR)/$$(cat "$(MULTISTARTER_SB16_ALIAS)")"; \
+	test -f "$$sb14" || { echo "Missing Starboard 14 starter resolved from $(MULTISTARTER_SB14_ALIAS): $$sb14"; exit 1; }; \
+	test -f "$$sb16" || { echo "Missing Starboard 16 starter resolved from $(MULTISTARTER_SB16_ALIAS): $$sb16"; exit 1; }; \
+	case "$(MULTISTARTER_DEFAULT)" in auto|sb13|sb14|sb16) ;; *) echo "MULTISTARTER_DEFAULT must be auto, sb13, sb14 or sb16"; exit 1;; esac
 
 .PHONY: multistarter-package
 multistarter-package: multistarter-check
@@ -45,10 +46,13 @@ multistarter-package: multistarter-check
 	$(MAKE) "$(WORKDIR)/image/usr/palm/applications/$(PACKAGE_NAME_OFFICIAL)/cobalt" $(MULTISTARTER_MAKE_ARGS)
 	$(MAKE) "$(WORKDIR)/cobalt" $(MULTISTARTER_MAKE_ARGS)
 	$(MAKE) "$(WORKDIR)/ipk/content/app/cobalt/content/web/adblock" $(MULTISTARTER_MAKE_ARGS)
+	@set -eu; \
+	sb14="$(PRIVATE_IMAGES_DIR)/$$(cat "$(MULTISTARTER_SB14_ALIAS)")"; \
+	sb16="$(PRIVATE_IMAGES_DIR)/$$(cat "$(MULTISTARTER_SB16_ALIAS)")"; \
 	sh scripts/prepare-multistarter-package.sh \
 		"$(WORKDIR)/ipk" \
-		"$(MULTISTARTER_SB14_STARTER)" \
-		"$(MULTISTARTER_SB16_STARTER)" \
+		"$$sb14" \
+		"$$sb16" \
 		"$(MULTISTARTER_DEFAULT)"
 	$(MAKE) ares-package-docker $(MULTISTARTER_MAKE_ARGS)
 	mkdir -p "$(dir $(MULTISTARTER_IPK))"
@@ -63,11 +67,22 @@ multistarter-package: multistarter-check
 
 .PHONY: multistarter-status
 multistarter-status: images
-	@echo "Starboard 13 runtime: $(MULTISTARTER_SB13_COBALT_ARCHIVE)"
-	@test -f "$(MULTISTARTER_SB13_COBALT_ARCHIVE)" && echo "  OK" || echo "  MISSING"
-	@echo "Starboard 14 alias: $(MULTISTARTER_SB14_ALIAS)"
-	@echo "Starboard 14 starter: $(MULTISTARTER_SB14_STARTER)"
-	@test -f "$(MULTISTARTER_SB14_STARTER)" && echo "  OK" || echo "  MISSING"
-	@echo "Starboard 16 alias: $(MULTISTARTER_SB16_ALIAS)"
-	@echo "Starboard 16 starter: $(MULTISTARTER_SB16_STARTER)"
-	@test -f "$(MULTISTARTER_SB16_STARTER)" && echo "  OK" || echo "  MISSING"
+	@set -u; \
+	echo "Starboard 13 runtime: $(MULTISTARTER_SB13_COBALT_ARCHIVE)"; \
+	test -f "$(MULTISTARTER_SB13_COBALT_ARCHIVE)" && echo "  OK" || echo "  MISSING"; \
+	echo "Starboard 14 alias: $(MULTISTARTER_SB14_ALIAS)"; \
+	if test -f "$(MULTISTARTER_SB14_ALIAS)"; then \
+		sb14="$(PRIVATE_IMAGES_DIR)/$$(cat "$(MULTISTARTER_SB14_ALIAS)")"; \
+		echo "Starboard 14 starter: $$sb14"; \
+		test -f "$$sb14" && echo "  OK" || echo "  MISSING"; \
+	else \
+		echo "  MISSING ALIAS"; \
+	fi; \
+	echo "Starboard 16 alias: $(MULTISTARTER_SB16_ALIAS)"; \
+	if test -f "$(MULTISTARTER_SB16_ALIAS)"; then \
+		sb16="$(PRIVATE_IMAGES_DIR)/$$(cat "$(MULTISTARTER_SB16_ALIAS)")"; \
+		echo "Starboard 16 starter: $$sb16"; \
+		test -f "$$sb16" && echo "  OK" || echo "  MISSING"; \
+	else \
+		echo "  MISSING ALIAS"; \
+	fi

--- a/Makefile.multistarter
+++ b/Makefile.multistarter
@@ -6,9 +6,16 @@ include Makefile
 MULTISTARTER_VERSION?=1.2.190
 MULTISTARTER_DISPLAY_NAME?=YouTube Cobalt AdFree Multi-Starter Test
 MULTISTARTER_DEFAULT?=auto
+
+# Public build configuration is intentionally keyed by ABI, not TV model.
+# The private images repository maps these stable aliases to the currently
+# selected, provenance-documented stock starter dumps.
 MULTISTARTER_SB13_COBALT_ARCHIVE?=$(or $(wildcard cobalt-bin/23.lts.6-13.xz),$(PRIVATE_IMAGES_DIR)/cobalt-bin/23.lts.6-13.xz)
-MULTISTARTER_SB14_STARTER?=$(PRIVATE_IMAGES_DIR)/starters/oled48c48la-webos-9.2.2/cobalt
-MULTISTARTER_SB16_STARTER?=$(PRIVATE_IMAGES_DIR)/starters/oled55c36lc-webos-10.3.1/cobalt
+MULTISTARTER_SB14_ALIAS?=$(PRIVATE_IMAGES_DIR)/starters/by-starboard/sb14.path
+MULTISTARTER_SB16_ALIAS?=$(PRIVATE_IMAGES_DIR)/starters/by-starboard/sb16.path
+MULTISTARTER_SB14_STARTER?=$(PRIVATE_IMAGES_DIR)/$(shell cat "$(MULTISTARTER_SB14_ALIAS)" 2>/dev/null)
+MULTISTARTER_SB16_STARTER?=$(PRIVATE_IMAGES_DIR)/$(shell cat "$(MULTISTARTER_SB16_ALIAS)" 2>/dev/null)
+
 MULTISTARTER_IPK=$(PACKAGE_OUTPUT_DIR)/$(PACKAGE_NAME)_$(MULTISTARTER_VERSION)_arm.ipk
 MULTISTARTER_BUILT_IPK=$(WORKDIR)/ipk-output/$(PACKAGE_NAME)_$(MULTISTARTER_VERSION)_arm.ipk
 
@@ -24,14 +31,16 @@ MULTISTARTER_MAKE_ARGS=\
 	PACKAGE_COBALT_ARCHIVE="$(MULTISTARTER_SB13_COBALT_ARCHIVE)"
 
 .PHONY: multistarter-check
-multistarter-check:
+multistarter-check: images
 	@test -f "$(MULTISTARTER_SB13_COBALT_ARCHIVE)" || (echo "Missing Starboard 13 Cobalt archive: $(MULTISTARTER_SB13_COBALT_ARCHIVE)" && exit 1)
-	@test -f "$(MULTISTARTER_SB14_STARTER)" || (echo "Missing webOS 24 / Starboard 14 starter: $(MULTISTARTER_SB14_STARTER)" && echo "Extract OLED48C48.zip as described in docs/multistarter-test-package.md or override MULTISTARTER_SB14_STARTER." && exit 1)
-	@test -f "$(MULTISTARTER_SB16_STARTER)" || (echo "Missing webOS 25 / Starboard 16 starter: $(MULTISTARTER_SB16_STARTER)" && exit 1)
+	@test -f "$(MULTISTARTER_SB14_ALIAS)" || (echo "Missing Starboard 14 alias: $(MULTISTARTER_SB14_ALIAS)" && exit 1)
+	@test -f "$(MULTISTARTER_SB16_ALIAS)" || (echo "Missing Starboard 16 alias: $(MULTISTARTER_SB16_ALIAS)" && exit 1)
+	@test -f "$(MULTISTARTER_SB14_STARTER)" || (echo "Missing Starboard 14 starter resolved from $(MULTISTARTER_SB14_ALIAS): $(MULTISTARTER_SB14_STARTER)" && exit 1)
+	@test -f "$(MULTISTARTER_SB16_STARTER)" || (echo "Missing Starboard 16 starter resolved from $(MULTISTARTER_SB16_ALIAS): $(MULTISTARTER_SB16_STARTER)" && exit 1)
 	@case "$(MULTISTARTER_DEFAULT)" in auto|sb13|sb14|sb16) ;; *) echo "MULTISTARTER_DEFAULT must be auto, sb13, sb14 or sb16"; exit 1;; esac
 
 .PHONY: multistarter-package
-multistarter-package: images multistarter-check
+multistarter-package: multistarter-check
 	$(MAKE) clean-ipk
 	$(MAKE) "$(WORKDIR)/image/usr/palm/applications/$(PACKAGE_NAME_OFFICIAL)/cobalt" $(MULTISTARTER_MAKE_ARGS)
 	$(MAKE) "$(WORKDIR)/cobalt" $(MULTISTARTER_MAKE_ARGS)
@@ -56,7 +65,9 @@ multistarter-package: images multistarter-check
 multistarter-status: images
 	@echo "Starboard 13 runtime: $(MULTISTARTER_SB13_COBALT_ARCHIVE)"
 	@test -f "$(MULTISTARTER_SB13_COBALT_ARCHIVE)" && echo "  OK" || echo "  MISSING"
+	@echo "Starboard 14 alias: $(MULTISTARTER_SB14_ALIAS)"
 	@echo "Starboard 14 starter: $(MULTISTARTER_SB14_STARTER)"
 	@test -f "$(MULTISTARTER_SB14_STARTER)" && echo "  OK" || echo "  MISSING"
+	@echo "Starboard 16 alias: $(MULTISTARTER_SB16_ALIAS)"
 	@echo "Starboard 16 starter: $(MULTISTARTER_SB16_STARTER)"
 	@test -f "$(MULTISTARTER_SB16_STARTER)" && echo "  OK" || echo "  MISSING"

--- a/Makefile.multistarter
+++ b/Makefile.multistarter
@@ -1,0 +1,62 @@
+# Experimental package that selects an LG Cobalt starter at launch time.
+# Use explicitly: make -f Makefile.multistarter multistarter-package
+
+include Makefile
+
+MULTISTARTER_VERSION?=1.2.190
+MULTISTARTER_DISPLAY_NAME?=YouTube Cobalt AdFree Multi-Starter Test
+MULTISTARTER_DEFAULT?=auto
+MULTISTARTER_SB13_COBALT_ARCHIVE?=$(or $(wildcard cobalt-bin/23.lts.6-13.xz),$(PRIVATE_IMAGES_DIR)/cobalt-bin/23.lts.6-13.xz)
+MULTISTARTER_SB14_STARTER?=$(PRIVATE_IMAGES_DIR)/starters/oled48c48la-webos-9.2.2/cobalt
+MULTISTARTER_SB16_STARTER?=$(PRIVATE_IMAGES_DIR)/starters/oled55c36lc-webos-10.3.1/cobalt
+MULTISTARTER_IPK=$(PACKAGE_OUTPUT_DIR)/$(PACKAGE_NAME)_$(MULTISTARTER_VERSION)_arm.ipk
+MULTISTARTER_BUILT_IPK=$(WORKDIR)/ipk-output/$(PACKAGE_NAME)_$(MULTISTARTER_VERSION)_arm.ipk
+
+MULTISTARTER_MAKE_ARGS=\
+	PACKAGE="$(OFFICAL_YOUTUBE_IPK)" \
+	PACKAGE_NAME_OFFICIAL="$(PACKAGE_NAME_OFFICIAL)" \
+	PACKAGE_NAME="$(PACKAGE_NAME)" \
+	PACKAGE_DISPLAY_NAME="$(MULTISTARTER_DISPLAY_NAME)" \
+	PACKAGE_VERSION="$(MULTISTARTER_VERSION)" \
+	PROJECT_VERSION="$(MULTISTARTER_VERSION)" \
+	PACKAGE_SB_API_VERSION=13 \
+	PACKAGE_COBALT_VERSION=23.lts.6 \
+	PACKAGE_COBALT_ARCHIVE="$(MULTISTARTER_SB13_COBALT_ARCHIVE)"
+
+.PHONY: multistarter-check
+multistarter-check:
+	@test -f "$(MULTISTARTER_SB13_COBALT_ARCHIVE)" || (echo "Missing Starboard 13 Cobalt archive: $(MULTISTARTER_SB13_COBALT_ARCHIVE)" && exit 1)
+	@test -f "$(MULTISTARTER_SB14_STARTER)" || (echo "Missing webOS 24 / Starboard 14 starter: $(MULTISTARTER_SB14_STARTER)" && echo "Extract OLED48C48.zip as described in docs/multistarter-test-package.md or override MULTISTARTER_SB14_STARTER." && exit 1)
+	@test -f "$(MULTISTARTER_SB16_STARTER)" || (echo "Missing webOS 25 / Starboard 16 starter: $(MULTISTARTER_SB16_STARTER)" && exit 1)
+	@case "$(MULTISTARTER_DEFAULT)" in auto|sb13|sb14|sb16) ;; *) echo "MULTISTARTER_DEFAULT must be auto, sb13, sb14 or sb16"; exit 1;; esac
+
+.PHONY: multistarter-package
+multistarter-package: images multistarter-check
+	$(MAKE) clean-ipk
+	$(MAKE) "$(WORKDIR)/image/usr/palm/applications/$(PACKAGE_NAME_OFFICIAL)/cobalt" $(MULTISTARTER_MAKE_ARGS)
+	$(MAKE) "$(WORKDIR)/cobalt" $(MULTISTARTER_MAKE_ARGS)
+	$(MAKE) "$(WORKDIR)/ipk/content/app/cobalt/content/web/adblock" $(MULTISTARTER_MAKE_ARGS)
+	sh scripts/prepare-multistarter-package.sh \
+		"$(WORKDIR)/ipk" \
+		"$(MULTISTARTER_SB14_STARTER)" \
+		"$(MULTISTARTER_SB16_STARTER)" \
+		"$(MULTISTARTER_DEFAULT)"
+	$(MAKE) ares-package-docker $(MULTISTARTER_MAKE_ARGS)
+	mkdir -p "$(dir $(MULTISTARTER_IPK))"
+	python3 "$(IPK_MTIME_NORMALIZER)" --mtime "$(IPK_MEMBER_MTIME)" "$(MULTISTARTER_BUILT_IPK)"
+	mv "$(MULTISTARTER_BUILT_IPK)" "$(MULTISTARTER_IPK)"
+	@echo ""
+	@echo "Experimental multi-starter package:"
+	@echo "  $(MULTISTARTER_IPK)"
+	@echo ""
+	@echo "Selector log on the TV:"
+	@echo "  /tmp/ytaf-cobalt-selector.log"
+
+.PHONY: multistarter-status
+multistarter-status: images
+	@echo "Starboard 13 runtime: $(MULTISTARTER_SB13_COBALT_ARCHIVE)"
+	@test -f "$(MULTISTARTER_SB13_COBALT_ARCHIVE)" && echo "  OK" || echo "  MISSING"
+	@echo "Starboard 14 starter: $(MULTISTARTER_SB14_STARTER)"
+	@test -f "$(MULTISTARTER_SB14_STARTER)" && echo "  OK" || echo "  MISSING"
+	@echo "Starboard 16 starter: $(MULTISTARTER_SB16_STARTER)"
+	@test -f "$(MULTISTARTER_SB16_STARTER)" && echo "  OK" || echo "  MISSING"

--- a/docs/multistarter-test-package.md
+++ b/docs/multistarter-test-package.md
@@ -1,0 +1,73 @@
+# Experimental multi-starter IPK
+
+This branch builds one test IPK containing three LG Cobalt starter generations:
+
+| Profile | Automatic selection | Starter behavior |
+| --- | --- | --- |
+| `sb13` | webOS SDK 8.x and older, or unknown | Uses the packaged patched Cobalt 23.lts.6 / Starboard 13 runtime with `--evergreen_lite`. |
+| `sb14` | webOS SDK 9.x / webOS TV 24 | Uses the OLED48C48LA stock Cobalt 24.lts.60 / Starboard 14 loader with normal Evergreen slot management. |
+| `sb16` | webOS SDK 10.x and newer / webOS TV 25+ | Uses the OLED55C36LC stock Cobalt 25.lts.30 / Starboard 16 loader with normal Evergreen slot management. |
+
+This is deliberately a starter compatibility test, not yet a universal AdFree runtime. On webOS 24 and 25 the selected stock loader first tries the Evergreen installation already maintained by stock YouTube on that TV. If no matching slot remains after replacing the stock app, the loader can fall back to the packaged Starboard 13 library and fail its SABI check. That failure is useful diagnostic information for the next step: packaging matching patched API 14 and API 16 runtimes.
+
+## Add the webOS 24 starter
+
+The private images repository already contains the webOS 25 starter. The C4 dump uploaded separately can be used without committing it:
+
+```sh
+make images
+mkdir -p .private-images/starters/oled48c48la-webos-9.2.2
+unzip -p /path/to/OLED48C48.zip cobalt \
+  > .private-images/starters/oled48c48la-webos-9.2.2/cobalt
+chmod 0755 .private-images/starters/oled48c48la-webos-9.2.2/cobalt
+```
+
+A different location can be passed with `MULTISTARTER_SB14_STARTER=/path/to/cobalt`.
+
+## Build
+
+```sh
+make -f Makefile.multistarter multistarter-status
+make -f Makefile.multistarter multistarter-package
+```
+
+The package is written to:
+
+```text
+output/youtube.leanback.v4_1.2.190_arm.ipk
+```
+
+## Force a profile
+
+Automatic mapping can be overridden at build time:
+
+```sh
+make -f Makefile.multistarter multistarter-package MULTISTARTER_DEFAULT=sb14
+```
+
+Accepted values are `auto`, `sb13`, `sb14`, and `sb16`.
+
+For an already installed package, create one of these files containing a single profile name:
+
+```text
+/tmp/ytaf-cobalt-starter
+/media/developer/ytaf-cobalt-starter
+```
+
+Example:
+
+```sh
+printf '%s\n' sb14 > /tmp/ytaf-cobalt-starter
+```
+
+Restart the app after changing the override.
+
+## Diagnostics
+
+The selector records its decision here:
+
+```text
+/tmp/ytaf-cobalt-selector.log
+```
+
+Relevant Cobalt logs should show whether the selected loader found an Evergreen slot, loaded the system image, or rejected the runtime because of a SABI mismatch.

--- a/scripts/cobalt-selector.sh
+++ b/scripts/cobalt-selector.sh
@@ -1,0 +1,137 @@
+#!/bin/sh
+
+# Runtime selector for the experimental multi-starter YouTube package.
+# The launcher deliberately keeps Starboard 13 in Evergreen Lite mode, while
+# newer starters use LG's normal Evergreen slot management. This first test
+# therefore answers one question only: does the device-specific starter launch?
+
+set -u
+
+APP_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd -P)
+LOG_FILE=${YTAF_SELECTOR_LOG:-/tmp/ytaf-cobalt-selector.log}
+
+log() {
+    message="$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || true) $*"
+    printf '%s\n' "$message" >> "$LOG_FILE" 2>/dev/null || true
+    printf '%s\n' "$message" >&2
+}
+
+read_override() {
+    if [ -n "${YTAF_COBALT_STARTER:-}" ]; then
+        printf '%s\n' "$YTAF_COBALT_STARTER"
+        return
+    fi
+
+    for override_file in \
+        /tmp/ytaf-cobalt-starter \
+        /media/developer/ytaf-cobalt-starter \
+        "$APP_DIR/starter-override"
+    do
+        if [ -r "$override_file" ]; then
+            sed -n '1{s/[[:space:]]//g;p;}' "$override_file"
+            return
+        fi
+    done
+
+    printf '%s\n' auto
+}
+
+extract_version() {
+    for release_file in /etc/webos-release /etc/os-release; do
+        [ -r "$release_file" ] || continue
+
+        value=$(sed -n \
+            -e 's/^WEBOS_VERSION[[:space:]]*=[[:space:]]*//p' \
+            -e 's/^webos_release[[:space:]]*=[[:space:]]*//p' \
+            -e 's/^SDK_VERSION[[:space:]]*=[[:space:]]*//p' \
+            -e 's/^VERSION_ID[[:space:]]*=[[:space:]]*//p' \
+            "$release_file" | head -n 1 | tr -d '\"' | tr -d "'")
+
+        if [ -n "$value" ]; then
+            printf '%s\n' "$value"
+            return
+        fi
+    done
+
+    if command -v luna-send >/dev/null 2>&1; then
+        response=$(luna-send -n 1 -f \
+            luna://com.webos.service.tv.systemproperty/getSystemInfo \
+            '{"keys":["sdkVersion"]}' 2>/dev/null || true)
+        value=$(printf '%s\n' "$response" | sed -n 's/.*"sdkVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
+        if [ -n "$value" ]; then
+            printf '%s\n' "$value"
+            return
+        fi
+    fi
+
+    printf '%s\n' unknown
+}
+
+select_profile() {
+    override=$(read_override)
+    case "$override" in
+        sb13|sb14|sb16)
+            printf '%s\n' "$override"
+            return
+            ;;
+        auto|'')
+            ;;
+        *)
+            log "Ignoring invalid starter override: $override"
+            ;;
+    esac
+
+    version=$(extract_version)
+    major=$(printf '%s\n' "$version" | sed -n 's/^[^0-9]*\([0-9][0-9]*\).*/\1/p')
+
+    case "$major" in
+        ''|*[!0-9]*)
+            log "Could not detect webOS SDK version (value: $version); falling back to sb13"
+            printf '%s\n' sb13
+            ;;
+        *)
+            if [ "$major" -ge 10 ]; then
+                printf '%s\n' sb16
+            elif [ "$major" -ge 9 ]; then
+                printf '%s\n' sb14
+            else
+                printf '%s\n' sb13
+            fi
+            ;;
+    esac
+}
+
+profile=$(select_profile)
+starter="$APP_DIR/starters/cobalt-$profile"
+
+if [ ! -x "$starter" ]; then
+    log "Selected starter is missing or not executable: $starter"
+    fallback="$APP_DIR/starters/cobalt-sb13"
+    if [ ! -x "$fallback" ]; then
+        log "Fallback starter is also unavailable: $fallback"
+        exit 127
+    fi
+    profile=sb13
+    starter=$fallback
+fi
+
+version=$(extract_version)
+log "webOS SDK=$version profile=$profile starter=$starter"
+
+case "$profile" in
+    sb13)
+        # The packaged patched Cobalt 23.lts.6 / Starboard 13 runtime is used.
+        exec "$starter" --evergreen_lite "$@"
+        ;;
+    sb14|sb16)
+        # Do not force Evergreen Lite here. The device-specific stock loader can
+        # first try the Evergreen installation already maintained by stock
+        # YouTube on the TV. If no matching slot exists, its own logs should
+        # reveal the fallback/SABI failure.
+        exec "$starter" "$@"
+        ;;
+    *)
+        log "Internal error: unsupported profile $profile"
+        exit 64
+        ;;
+esac

--- a/scripts/prepare-multistarter-package.sh
+++ b/scripts/prepare-multistarter-package.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -ne 4 ]; then
+    echo "Usage: $0 APP_DIR SB14_STARTER SB16_STARTER DEFAULT_PROFILE" >&2
+    exit 64
+fi
+
+app_dir=$1
+sb14_starter=$2
+sb16_starter=$3
+default_profile=$4
+selector_source=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)/cobalt-selector.sh
+
+case "$default_profile" in
+    auto|sb13|sb14|sb16) ;;
+    *)
+        echo "Invalid DEFAULT_PROFILE: $default_profile" >&2
+        exit 64
+        ;;
+esac
+
+for required in \
+    "$app_dir/cobalt" \
+    "$app_dir/appinfo.json" \
+    "$selector_source" \
+    "$sb14_starter" \
+    "$sb16_starter"
+do
+    if [ ! -f "$required" ]; then
+        echo "Missing required file: $required" >&2
+        exit 1
+    fi
+done
+
+mkdir -p "$app_dir/starters"
+
+mv "$app_dir/cobalt" "$app_dir/starters/cobalt-sb13"
+cp "$sb14_starter" "$app_dir/starters/cobalt-sb14"
+cp "$sb16_starter" "$app_dir/starters/cobalt-sb16"
+chmod 0755 "$app_dir/starters/cobalt-sb13" \
+           "$app_dir/starters/cobalt-sb14" \
+           "$app_dir/starters/cobalt-sb16"
+
+cp "$selector_source" "$app_dir/cobalt"
+chmod 0755 "$app_dir/cobalt"
+
+if [ -f "$app_dir/switches" ]; then
+    sed '/--evergreen_lite/d' "$app_dir/switches" > "$app_dir/switches.multistarter"
+    mv "$app_dir/switches.multistarter" "$app_dir/switches"
+fi
+
+printf '%s\n' "$default_profile" > "$app_dir/starter-override"
+
+hash_file() {
+    file=$1
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$file" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$file" | awk '{print $1}'
+    else
+        printf '%s\n' unavailable
+    fi
+}
+
+cat > "$app_dir/multistarter.json" <<EOF_JSON
+{
+  "default": "$default_profile",
+  "profiles": {
+    "sb13": {
+      "webos": "8.x and older/unknown",
+      "mode": "evergreen_lite",
+      "sha256": "$(hash_file "$app_dir/starters/cobalt-sb13")"
+    },
+    "sb14": {
+      "webos": "9.x (webOS TV 24)",
+      "mode": "evergreen_slots",
+      "sha256": "$(hash_file "$app_dir/starters/cobalt-sb14")"
+    },
+    "sb16": {
+      "webos": "10.x and newer (webOS TV 25+)",
+      "mode": "evergreen_slots",
+      "sha256": "$(hash_file "$app_dir/starters/cobalt-sb16")"
+    }
+  }
+}
+EOF_JSON
+
+echo "Prepared multi-starter application in $app_dir"


### PR DESCRIPTION
## What changed

- adds a launch-time selector for Starboard 13, 14 and 16 LG Cobalt starters
- maps webOS SDK 9.x to the OLED48C48LA Cobalt 24.lts.60 / API 14 starter
- maps webOS SDK 10.x+ to the OLED55C36LC Cobalt 25.lts.30 / API 16 starter
- keeps the existing patched Cobalt 23.lts.6 / API 13 runtime as the legacy fallback
- adds manual profile overrides and selector logging
- adds an isolated `Makefile.multistarter` build target and test documentation

## Why

Recent stock dumps use different Cobalt loader and Starboard generations. A single hard-coded starter cannot cover webOS 24 and webOS 25 reliably. This branch creates one diagnostic IPK that selects the device-appropriate stock starter at launch.

## Current limitation

The package only contains the patched API 13 Cobalt runtime. API 14 and API 16 starters initially use LG's normal Evergreen slot management so a test can establish whether the matching stock Evergreen runtime remains available on the TV. If it does not, the expected SABI failure will identify the need to build and package matching patched API 14/API 16 runtimes.

The webOS 24 starter from `OLED48C48.zip` is intentionally kept as local/private build input and is not committed to this public repository.

## Validation

- both shell scripts pass `sh -n`
- branch diff is isolated to four new files
- existing default build targets are unchanged
