### PR TITLE
fix(UHD): solves VP9 UHD capability detection on compatible displays

### DIFF
--- a/cobalt-patches/cobalt-23.lts.6.patch
+++ b/cobalt-patches/cobalt-23.lts.6.patch
@@ -469,8 +469,8 @@ index aedc5c6f5..194fb18c8 100644
 +  if (codec != "vp9" && codec != "vp09") {
 +    const std::vector<std::string> codec_parts = base::SplitString(
 +        codec, ".", base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
-+    if ((codec_parts.size() != 4 && codec_parts.size() != 9 &&
-+         codec_parts.size() != 10) ||
++    if ((codec_parts.size() != 4 && codec_parts.size() != 8 &&
++         codec_parts.size() != 9) ||
 +        codec_parts[0] != "vp09" || codec_parts[1] != "00") {
 +      return false;
 +    }
@@ -504,7 +504,7 @@ index aedc5c6f5..194fb18c8 100644
 +      }
 +    }
 +
-+    if (codec_parts.size() == 10) {
++    if (codec_parts.size() == 9) {
 +      int color_range = 0;
 +      if (!ParseVp09Component(codec_parts[8], 0, 1, &color_range)) {
 +        return false;

--- a/cobalt-patches/cobalt-23.lts.6.patch
+++ b/cobalt-patches/cobalt-23.lts.6.patch
@@ -281,7 +281,7 @@ index aedc5c6f5..194fb18c8 100644
  #include "base/strings/string_split.h"
  #include "base/synchronization/waitable_event.h"
  #include "cobalt/media/base/format_support_query_metrics.h"
-@@ -91,6 +92,309 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
+@@ -91,6 +92,312 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
    return "";
  }
  
@@ -487,6 +487,9 @@ index aedc5c6f5..194fb18c8 100644
 +  }
 +
 +  const std::string& codec = codecs[0];
++  if (codec.find_first_of(" \t\r\n") != std::string::npos) {
++    return false;
++  }
 +  int vp09_level = 0;
 +  int vp09_transfer = 1;
 +  const bool has_structured_vp09_codec = codec != "vp9" && codec != "vp09";
@@ -591,7 +594,7 @@ index aedc5c6f5..194fb18c8 100644
  class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
   public:
    void SetDisabledMediaCodecs(
-@@ -171,6 +461,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
+@@ -171,6 +467,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
      }
      SbMediaSupportType type =
          SbMediaCanPlayMimeAndKeySystem(mime_type.c_str(), key_system.c_str());

--- a/cobalt-patches/cobalt-23.lts.6.patch
+++ b/cobalt-patches/cobalt-23.lts.6.patch
@@ -281,7 +281,7 @@ index aedc5c6f5..194fb18c8 100644
  #include "base/strings/string_split.h"
  #include "base/synchronization/waitable_event.h"
  #include "cobalt/media/base/format_support_query_metrics.h"
-@@ -91,6 +92,277 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
+@@ -91,6 +92,282 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
    return "";
  }
  
@@ -465,6 +465,7 @@ index aedc5c6f5..194fb18c8 100644
 +
 +  const std::string& codec = codecs[0];
 +  int vp09_level = 0;
++  int vp09_transfer = 1;
 +  const bool has_structured_vp09_codec = codec != "vp9" && codec != "vp09";
 +  if (codec != "vp9" && codec != "vp09") {
 +    const std::vector<std::string> codec_parts = base::SplitString(
@@ -498,8 +499,11 @@ index aedc5c6f5..194fb18c8 100644
 +      int component = 0;
 +      if (!ParseVp09Component(codec_parts[4], 0, 1, &component) ||
 +          !ParseVp09Component(codec_parts[5], 1, 12, &component) ||
-+          !ParseVp09Component(codec_parts[6], 0, 18, &component) ||
++          !ParseVp09Component(codec_parts[6], 0, 18, &vp09_transfer) ||
 +          !ParseVp09Component(codec_parts[7], 0, 11, &component)) {
++        return false;
++      }
++      if (vp09_transfer != 1) {
 +        return false;
 +      }
 +    }
@@ -536,8 +540,9 @@ index aedc5c6f5..194fb18c8 100644
 +  }
 +
 +  std::string eotf;
-+  return !ExtractMimeTypeParameter(mime_type, "eotf", &eotf) ||
-+         eotf == "bt709";
++  return (!has_structured_vp09_codec || vp09_transfer == 1) &&
++         (!ExtractMimeTypeParameter(mime_type, "eotf", &eotf) ||
++          eotf == "bt709");
 +}
 +
 +static bool Has4kVideoOutput() {
@@ -559,7 +564,7 @@ index aedc5c6f5..194fb18c8 100644
  class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
   public:
    void SetDisabledMediaCodecs(
-@@ -171,6 +442,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
+@@ -171,6 +449,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
      }
      SbMediaSupportType type =
          SbMediaCanPlayMimeAndKeySystem(mime_type.c_str(), key_system.c_str());

--- a/cobalt-patches/cobalt-23.lts.6.patch
+++ b/cobalt-patches/cobalt-23.lts.6.patch
@@ -281,7 +281,7 @@ index aedc5c6f5..194fb18c8 100644
  #include "base/strings/string_split.h"
  #include "base/synchronization/waitable_event.h"
  #include "cobalt/media/base/format_support_query_metrics.h"
-@@ -91,6 +92,282 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
+@@ -91,6 +92,294 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
    return "";
  }
  
@@ -322,6 +322,14 @@ index aedc5c6f5..194fb18c8 100644
 +    return false;
 +  }
 +  return *value >= minimum && *value <= maximum;
++}
++
++static bool IsVp09ColorPrimaries(int value) {
++  return value == 1 || value == 2 || (value >= 4 && value <= 12);
++}
++
++static bool IsVp09MatrixCoefficients(int value) {
++  return (value >= 0 && value <= 2) || (value >= 4 && value <= 11);
 +}
 +
 +static int64_t GetVp09MaximumLumaSampleRate(int level) {
@@ -497,10 +505,14 @@ index aedc5c6f5..194fb18c8 100644
 +
 +    if (codec_parts.size() > 4) {
 +      int component = 0;
++      int color_primaries = 0;
++      int matrix_coefficients = 0;
 +      if (!ParseVp09Component(codec_parts[4], 0, 1, &component) ||
-+          !ParseVp09Component(codec_parts[5], 1, 12, &component) ||
++          !ParseVp09Component(codec_parts[5], 1, 12, &color_primaries) ||
 +          !ParseVp09Component(codec_parts[6], 0, 18, &vp09_transfer) ||
-+          !ParseVp09Component(codec_parts[7], 0, 11, &component)) {
++          !ParseVp09Component(codec_parts[7], 0, 11, &matrix_coefficients) ||
++          !IsVp09ColorPrimaries(color_primaries) ||
++          !IsVp09MatrixCoefficients(matrix_coefficients)) {
 +        return false;
 +      }
 +      if (vp09_transfer != 1) {
@@ -564,7 +576,7 @@ index aedc5c6f5..194fb18c8 100644
  class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
   public:
    void SetDisabledMediaCodecs(
-@@ -171,6 +449,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
+@@ -171,6 +456,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
      }
      SbMediaSupportType type =
          SbMediaCanPlayMimeAndKeySystem(mime_type.c_str(), key_system.c_str());

--- a/cobalt-patches/cobalt-23.lts.6.patch
+++ b/cobalt-patches/cobalt-23.lts.6.patch
@@ -281,7 +281,7 @@ index aedc5c6f5..194fb18c8 100644
  #include "base/strings/string_split.h"
  #include "base/synchronization/waitable_event.h"
  #include "cobalt/media/base/format_support_query_metrics.h"
-@@ -91,6 +92,123 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
+@@ -91,6 +92,125 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
    return "";
  }
  
@@ -313,7 +313,9 @@ index aedc5c6f5..194fb18c8 100644
 +}
 +
 +static bool IsExplicitVp9SdrUhdQuery(const std::string& mime_type) {
-+  if (mime_type.find("video/") != 0) {
++  const std::vector<std::string> mime_components = base::SplitString(
++      mime_type, ";", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
++  if (mime_components.empty() || mime_components[0] != "video/webm") {
 +    return false;
 +  }
 +
@@ -349,7 +351,7 @@ index aedc5c6f5..194fb18c8 100644
 +         level != "40" && level != "41" && level != "50" &&
 +         level != "51" && level != "52" && level != "60" &&
 +         level != "61" && level != "62") ||
-+        (bit_depth != "08" && bit_depth != "10" && bit_depth != "12")) {
++        bit_depth != "08") {
 +      return false;
 +    }
 +
@@ -405,7 +407,7 @@ index aedc5c6f5..194fb18c8 100644
  class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
   public:
    void SetDisabledMediaCodecs(
-@@ -171,6 +289,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
+@@ -171,6 +291,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
      }
      SbMediaSupportType type =
          SbMediaCanPlayMimeAndKeySystem(mime_type.c_str(), key_system.c_str());

--- a/cobalt-patches/cobalt-23.lts.6.patch
+++ b/cobalt-patches/cobalt-23.lts.6.patch
@@ -281,7 +281,7 @@ index aedc5c6f5..194fb18c8 100644
  #include "base/strings/string_split.h"
  #include "base/synchronization/waitable_event.h"
  #include "cobalt/media/base/format_support_query_metrics.h"
-@@ -91,6 +92,85 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
+@@ -91,6 +92,117 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
    return "";
  }
  
@@ -318,10 +318,42 @@ index aedc5c6f5..194fb18c8 100644
 +  }
 +
 +  const std::vector<std::string> codecs = ExtractCodecs(mime_type);
-+  if (codecs.size() != 1 ||
-+      (codecs[0] != "vp9" && codecs[0] != "vp09" &&
-+       codecs[0].find("vp09.00.") != 0)) {
++  if (codecs.size() != 1) {
 +    return false;
++  }
++
++  const std::string& codec = codecs[0];
++  if (codec != "vp9" && codec != "vp09") {
++    const std::vector<std::string> codec_parts = base::SplitString(
++        codec, ".", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
++    if ((codec_parts.size() != 4 && codec_parts.size() != 9 &&
++         codec_parts.size() != 10) ||
++        codec_parts[0] != "vp09" || codec_parts[1] != "00") {
++      return false;
++    }
++
++    const std::string& level = codec_parts[2];
++    const std::string& bit_depth = codec_parts[3];
++    if (level.size() != 2 ||
++        level.find_first_not_of("0123456789") != std::string::npos ||
++        bit_depth.size() != 2 ||
++        bit_depth.find_first_not_of("0123456789") != std::string::npos ||
++        (level != "10" && level != "11" && level != "20" &&
++         level != "21" && level != "30" && level != "31" &&
++         level != "40" && level != "41" && level != "50" &&
++         level != "51" && level != "52" && level != "60" &&
++         level != "61" && level != "62") ||
++        (bit_depth != "08" && bit_depth != "10" && bit_depth != "12")) {
++      return false;
++    }
++
++    for (size_t index = 4; index < codec_parts.size(); ++index) {
++      if (codec_parts[index].size() != 2 ||
++          codec_parts[index].find_first_not_of("0123456789") !=
++              std::string::npos) {
++        return false;
++      }
++    }
 +  }
 +
 +  int width = 0;
@@ -367,7 +399,7 @@ index aedc5c6f5..194fb18c8 100644
  class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
   public:
    void SetDisabledMediaCodecs(
-@@ -171,6 +251,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
+@@ -171,6 +283,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
      }
      SbMediaSupportType type =
          SbMediaCanPlayMimeAndKeySystem(mime_type.c_str(), key_system.c_str());

--- a/cobalt-patches/cobalt-23.lts.6.patch
+++ b/cobalt-patches/cobalt-23.lts.6.patch
@@ -270,25 +270,82 @@ index 1a1f7ba30..99bd40372 100644
    // 5. 6. Not needed by Cobalt.
 
 diff --git a/cobalt/media/media_module.cc b/cobalt/media/media_module.cc
-index aedc5c6f5..2b9cfd1f6 100644
+index aedc5c6f5..194fb18c8 100644
 --- a/cobalt/media/media_module.cc
 +++ b/cobalt/media/media_module.cc
-@@ -91,6 +91,36 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
+@@ -22,6 +22,7 @@
+ #include "base/bind.h"
+ #include "base/callback.h"
+ #include "base/logging.h"
++#include "base/strings/string_number_conversions.h"
+ #include "base/strings/string_split.h"
+ #include "base/synchronization/waitable_event.h"
+ #include "cobalt/media/base/format_support_query_metrics.h"
+@@ -91,6 +92,85 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
    return "";
  }
  
-+static bool IsVp9VideoMimeType(const std::string& mime_type) {
-+  if (mime_type.find("video/") == std::string::npos) {
++static bool ExtractMimeTypeParameter(const std::string& mime_type,
++                                     const std::string& parameter_name,
++                                     std::string* value) {
++  const std::vector<std::string> components = base::SplitString(
++      mime_type, ";", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
++  if (components.size() < 2) {
 +    return false;
 +  }
-+
-+  const std::vector<std::string> codecs = ExtractCodecs(mime_type);
-+  for (const auto& codec : codecs) {
-+    if (codec.find("vp9") == 0 || codec.find("vp09") == 0) {
++  for (auto iter = components.begin() + 1; iter != components.end(); ++iter) {
++    std::vector<std::string> name_and_value = base::SplitString(
++        *iter, "=", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
++    if (name_and_value.size() == 2 && name_and_value[0] == parameter_name) {
++      base::RemoveChars(name_and_value[1], "\"", value);
 +      return true;
 +    }
 +  }
 +  return false;
++}
++
++static bool ExtractMimeTypeIntParameter(const std::string& mime_type,
++                                        const std::string& parameter_name,
++                                        int* value) {
++  std::string string_value;
++  return ExtractMimeTypeParameter(mime_type, parameter_name, &string_value) &&
++         base::StringToInt(string_value, value);
++}
++
++static bool IsExplicitVp9SdrUhdQuery(const std::string& mime_type) {
++  if (mime_type.find("video/") != 0) {
++    return false;
++  }
++
++  const std::vector<std::string> codecs = ExtractCodecs(mime_type);
++  if (codecs.size() != 1 ||
++      (codecs[0] != "vp9" && codecs[0] != "vp09" &&
++       codecs[0].find("vp09.00.") != 0)) {
++    return false;
++  }
++
++  int width = 0;
++  int height = 0;
++  int frame_rate = 0;
++  int bitrate = 0;
++  if (!ExtractMimeTypeIntParameter(mime_type, "width", &width) ||
++      !ExtractMimeTypeIntParameter(mime_type, "height", &height) ||
++      !ExtractMimeTypeIntParameter(mime_type, "framerate", &frame_rate) ||
++      !ExtractMimeTypeIntParameter(mime_type, "bitrate", &bitrate)) {
++    return false;
++  }
++
++  const bool is_supported_resolution =
++      (width == 2560 && height == 1440) ||
++      (width == 3840 && height == 2160);
++  if (!is_supported_resolution || frame_rate <= 0 || frame_rate > 60 ||
++      bitrate <= 0 || bitrate > 60000000) {
++    return false;
++  }
++
++  std::string eotf;
++  return !ExtractMimeTypeParameter(mime_type, "eotf", &eotf) ||
++         eotf == "bt709";
 +}
 +
 +static bool Has4kVideoOutput() {
@@ -310,19 +367,17 @@ index aedc5c6f5..2b9cfd1f6 100644
  class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
   public:
    void SetDisabledMediaCodecs(
-@@ -171,6 +201,19 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
+@@ -171,6 +251,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
      }
      SbMediaSupportType type =
          SbMediaCanPlayMimeAndKeySystem(mime_type.c_str(), key_system.c_str());
 +
-+    // Some LG webOS Starboard implementations report VP9 as unsupported for
-+    // UHD profiles even though the same hardware plays VP9 UHD in the stock
-+    // YouTube application.  Only override clear VP9 queries on devices whose
-+    // effective video output is at least 3840x2160.  The graphics/UI surface
-+    // may remain 1920x1080; GetVideoOutputResolution() accounts for the
-+    // platform's video pixel ratio.
++    // Override only explicit, sane VP9 profile 0 SDR 1440p/2160p capability
++    // probes.  In particular, preserve Starboard's answer for generic VP9,
++    // HDR/profile 2, DRM, and deliberate sentinel probes with impossible
++    // dimensions, frame rates, bitrates, or transfer functions.
 +    if (type == kSbMediaSupportTypeNotSupported && key_system.empty() &&
-+        IsVp9VideoMimeType(mime_type) && Has4kVideoOutput()) {
++        IsExplicitVp9SdrUhdQuery(mime_type) && Has4kVideoOutput()) {
 +      LOG(WARNING) << "[YTAF] Forcing VP9 support on UHD output: "
 +                   << mime_type;
 +      return kSbMediaSupportTypeProbably;

--- a/cobalt-patches/cobalt-23.lts.6.patch
+++ b/cobalt-patches/cobalt-23.lts.6.patch
@@ -281,7 +281,7 @@ index aedc5c6f5..194fb18c8 100644
  #include "base/strings/string_split.h"
  #include "base/synchronization/waitable_event.h"
  #include "cobalt/media/base/format_support_query_metrics.h"
-@@ -91,6 +92,125 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
+@@ -91,6 +92,277 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
    return "";
  }
  
@@ -312,6 +312,145 @@ index aedc5c6f5..194fb18c8 100644
 +         base::StringToInt(string_value, value);
 +}
 +
++static bool ParseVp09Component(const std::string& component,
++                               int minimum,
++                               int maximum,
++                               int* value) {
++  if (component.size() != 2 ||
++      component.find_first_not_of("0123456789") != std::string::npos ||
++      !base::StringToInt(component, value)) {
++    return false;
++  }
++  return *value >= minimum && *value <= maximum;
++}
++
++static int64_t GetVp09MaximumLumaSampleRate(int level) {
++  switch (level) {
++    case 10:
++      return 829440;
++    case 11:
++      return 2764800;
++    case 20:
++      return 4608000;
++    case 21:
++      return 9216000;
++    case 30:
++      return 20736000;
++    case 31:
++      return 36864000;
++    case 40:
++      return 83558400;
++    case 41:
++      return 160432128;
++    case 50:
++      return 311951360;
++    case 51:
++      return 588251136;
++    case 52:
++      return 1176502272;
++    case 60:
++      return 1176502272;
++    case 61:
++      return 2353004544LL;
++    case 62:
++      return 4706010000LL;
++    default:
++      return 0;
++  }
++}
++
++static int64_t GetVp09MaximumPictureSize(int level) {
++  switch (level) {
++    case 10:
++      return 36864;
++    case 11:
++      return 73728;
++    case 20:
++      return 122880;
++    case 21:
++      return 245760;
++    case 30:
++      return 552960;
++    case 31:
++      return 983040;
++    case 40:
++    case 41:
++      return 2228224;
++    case 50:
++    case 51:
++    case 52:
++      return 8912896;
++    case 60:
++    case 61:
++    case 62:
++      return 35651584;
++    default:
++      return 0;
++  }
++}
++
++static int GetVp09MaximumDimension(int level) {
++  if (level >= 60) return 16832;
++  if (level >= 50) return 8384;
++  if (level >= 40) return 4160;
++  if (level >= 31) return 2752;
++  if (level >= 30) return 2048;
++  if (level >= 21) return 1344;
++  if (level >= 20) return 960;
++  if (level >= 11) return 768;
++  if (level >= 10) return 512;
++  return 0;
++}
++
++static int64_t GetVp09MaximumBitrate(int level) {
++  switch (level) {
++    case 10:
++      return 200000;
++    case 11:
++      return 800000;
++    case 20:
++      return 1800000;
++    case 21:
++      return 3600000;
++    case 30:
++      return 7200000;
++    case 31:
++      return 12000000;
++    case 40:
++      return 18000000;
++    case 41:
++      return 30000000;
++    case 50:
++      return 60000000;
++    case 51:
++      return 120000000;
++    case 52:
++    case 60:
++      return 180000000;
++    case 61:
++      return 240000000;
++    case 62:
++      return 480000000;
++    default:
++      return 0;
++  }
++}
++
++static bool IsVp09LevelSufficient(int level,
++                                  int width,
++                                  int height,
++                                  int frame_rate,
++                                  int bitrate) {
++  const int64_t picture_size = static_cast<int64_t>(width) * height;
++  const int64_t luma_sample_rate = picture_size * frame_rate;
++  const int maximum_dimension = GetVp09MaximumDimension(level);
++  return maximum_dimension > 0 && width <= maximum_dimension &&
++         height <= maximum_dimension &&
++         picture_size <= GetVp09MaximumPictureSize(level) &&
++         luma_sample_rate <= GetVp09MaximumLumaSampleRate(level) &&
++         bitrate <= GetVp09MaximumBitrate(level);
++}
++
 +static bool IsExplicitVp9SdrUhdQuery(const std::string& mime_type) {
 +  const std::vector<std::string> mime_components = base::SplitString(
 +      mime_type, ";", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
@@ -325,6 +464,8 @@ index aedc5c6f5..194fb18c8 100644
 +  }
 +
 +  const std::string& codec = codecs[0];
++  int vp09_level = 0;
++  const bool has_structured_vp09_codec = codec != "vp9" && codec != "vp09";
 +  if (codec != "vp9" && codec != "vp09") {
 +    const std::vector<std::string> codec_parts = base::SplitString(
 +        codec, ".", base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
@@ -342,23 +483,30 @@ index aedc5c6f5..194fb18c8 100644
 +
 +    const std::string& level = codec_parts[2];
 +    const std::string& bit_depth = codec_parts[3];
-+    if (level.size() != 2 ||
-+        level.find_first_not_of("0123456789") != std::string::npos ||
-+        bit_depth.size() != 2 ||
-+        bit_depth.find_first_not_of("0123456789") != std::string::npos ||
++    int bit_depth_value = 0;
++    if (!ParseVp09Component(level, 0, 62, &vp09_level) ||
++        !ParseVp09Component(bit_depth, 8, 8, &bit_depth_value) ||
 +        (level != "10" && level != "11" && level != "20" &&
 +         level != "21" && level != "30" && level != "31" &&
 +         level != "40" && level != "41" && level != "50" &&
 +         level != "51" && level != "52" && level != "60" &&
-+         level != "61" && level != "62") ||
-+        bit_depth != "08") {
++         level != "61" && level != "62")) {
 +      return false;
 +    }
 +
-+    for (size_t index = 4; index < codec_parts.size(); ++index) {
-+      if (codec_parts[index].size() != 2 ||
-+          codec_parts[index].find_first_not_of("0123456789") !=
-+              std::string::npos) {
++    if (codec_parts.size() > 4) {
++      int component = 0;
++      if (!ParseVp09Component(codec_parts[4], 0, 1, &component) ||
++          !ParseVp09Component(codec_parts[5], 1, 12, &component) ||
++          !ParseVp09Component(codec_parts[6], 0, 18, &component) ||
++          !ParseVp09Component(codec_parts[7], 0, 11, &component)) {
++        return false;
++      }
++    }
++
++    if (codec_parts.size() == 10) {
++      int color_range = 0;
++      if (!ParseVp09Component(codec_parts[8], 0, 1, &color_range)) {
 +        return false;
 +      }
 +    }
@@ -380,6 +528,10 @@ index aedc5c6f5..194fb18c8 100644
 +      (width == 3840 && height == 2160);
 +  if (!is_supported_resolution || frame_rate <= 0 || frame_rate > 60 ||
 +      bitrate <= 0 || bitrate > 60000000) {
++    return false;
++  }
++  if (has_structured_vp09_codec &&
++      !IsVp09LevelSufficient(vp09_level, width, height, frame_rate, bitrate)) {
 +    return false;
 +  }
 +
@@ -407,7 +559,7 @@ index aedc5c6f5..194fb18c8 100644
  class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
   public:
    void SetDisabledMediaCodecs(
-@@ -171,6 +291,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
+@@ -171,6 +442,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
      }
      SbMediaSupportType type =
          SbMediaCanPlayMimeAndKeySystem(mime_type.c_str(), key_system.c_str());

--- a/cobalt-patches/cobalt-23.lts.6.patch
+++ b/cobalt-patches/cobalt-23.lts.6.patch
@@ -281,7 +281,7 @@ index aedc5c6f5..194fb18c8 100644
  #include "base/strings/string_split.h"
  #include "base/synchronization/waitable_event.h"
  #include "cobalt/media/base/format_support_query_metrics.h"
-@@ -91,6 +92,117 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
+@@ -91,6 +92,123 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
    return "";
  }
  
@@ -325,11 +325,17 @@ index aedc5c6f5..194fb18c8 100644
 +  const std::string& codec = codecs[0];
 +  if (codec != "vp9" && codec != "vp09") {
 +    const std::vector<std::string> codec_parts = base::SplitString(
-+        codec, ".", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
++        codec, ".", base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
 +    if ((codec_parts.size() != 4 && codec_parts.size() != 9 &&
 +         codec_parts.size() != 10) ||
 +        codec_parts[0] != "vp09" || codec_parts[1] != "00") {
 +      return false;
++    }
++
++    for (const auto& component : codec_parts) {
++      if (component.empty()) {
++        return false;
++      }
 +    }
 +
 +    const std::string& level = codec_parts[2];
@@ -399,7 +405,7 @@ index aedc5c6f5..194fb18c8 100644
  class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
   public:
    void SetDisabledMediaCodecs(
-@@ -171,6 +283,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
+@@ -171,6 +289,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
      }
      SbMediaSupportType type =
          SbMediaCanPlayMimeAndKeySystem(mime_type.c_str(), key_system.c_str());

--- a/cobalt-patches/cobalt-23.lts.6.patch
+++ b/cobalt-patches/cobalt-23.lts.6.patch
@@ -281,7 +281,7 @@ index aedc5c6f5..194fb18c8 100644
  #include "base/strings/string_split.h"
  #include "base/synchronization/waitable_event.h"
  #include "cobalt/media/base/format_support_query_metrics.h"
-@@ -91,6 +92,294 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
+@@ -91,6 +92,309 @@ static std::string ExtractEncryptionScheme(const std::string& key_system) {
    return "";
  }
  
@@ -297,7 +297,22 @@ index aedc5c6f5..194fb18c8 100644
 +    std::vector<std::string> name_and_value = base::SplitString(
 +        *iter, "=", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
 +    if (name_and_value.size() == 2 && name_and_value[0] == parameter_name) {
-+      base::RemoveChars(name_and_value[1], "\"", value);
++      const std::string& raw_value = name_and_value[1];
++      const bool starts_quoted = !raw_value.empty() && raw_value[0] == '"';
++      const bool ends_quoted = !raw_value.empty() && raw_value.back() == '"';
++      if (starts_quoted != ends_quoted ||
++          (starts_quoted && raw_value.size() < 2)) {
++        return false;
++      }
++      if (raw_value.find('"', starts_quoted ? 1 : 0) !=
++              (starts_quoted ? raw_value.size() - 1 : std::string::npos)) {
++        return false;
++      }
++      if (starts_quoted) {
++        *value = raw_value.substr(1, raw_value.size() - 2);
++      } else {
++        *value = raw_value;
++      }
 +      return true;
 +    }
 +  }
@@ -576,7 +591,7 @@ index aedc5c6f5..194fb18c8 100644
  class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
   public:
    void SetDisabledMediaCodecs(
-@@ -171,6 +456,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
+@@ -171,6 +461,17 @@ class CanPlayTypeHandlerStarboard : public CanPlayTypeHandler {
      }
      SbMediaSupportType type =
          SbMediaCanPlayMimeAndKeySystem(mime_type.c_str(), key_system.c_str());


### PR DESCRIPTION
## Summary
- allow Cobalt to expose VP9 1440p/2160p when Starboard incorrectly reports valid SDR UHD probes as unsupported
- restrict the override to profile-0 VP9, 1440p/2160p, 1-60 fps, sane bitrate, SDR, and a UHD video output
- preserve native capability responses for generic VP9, HDR/profile 2, DRM, invalid probes, and non-UHD displays

## Validation
- `git apply --check` against a clean Cobalt `23.lts.6` checkout
- repository smoke checks and Python syntax checks
- `npm ci && npm run build -- --env production --optimization-minimize`

Fixes #42
Related to #2