### PR TITLE
feat(shorts): add a toggle to hide YouTube Shorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ and potentially other PJTR/k7lp devices. It uses the stock PJTR app id,
 * Return YouTube Dislike support
 * Automatic account selection on startup
 * Playback speed support
+* Optional Shorts visibility
 * Optional autostart integration
 * Installable as patched `.ipk` package
 

--- a/webapp/src/adblock-main.js
+++ b/webapp/src/adblock-main.js
@@ -9,7 +9,7 @@ import './ui.js';
 import { handleLaunch, waitForChildAdd } from './utils';
 import { configRead } from './config.js';
 import { userScriptStartUI } from './ui.js';
-import { userScriptStartAdBlock } from './adblock.js';
+import { userScriptStartAdBlock, userScriptStartShorts } from './adblock.js';
 import { userScriptStartSponsorBlock } from './sponsorblock.js';
 import { userScriptStartReturnYouTubeDislike } from './returnyoutubedislike.js';
 import { resetAutoLogin } from './auto-login.js';
@@ -98,6 +98,7 @@ export async function startUserScript() {
 
   try {
     userScriptStartUI();
+    userScriptStartShorts();
     startDebugOverlay();
     console.info('[ytaf] UI started');
   } catch (err) {

--- a/webapp/src/adblock.css
+++ b/webapp/src/adblock.css
@@ -10,6 +10,12 @@ html.ytaf-adblock-enabled ytd-masthead-ad-v3-renderer {
   pointer-events: none !important;
 }
 
+html.ytaf-shorts-disabled .ytaf-hidden-shorts {
+  display: none !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
+}
+
 html.ytaf-adblock-enabled .ytaf-hidden-ad-tile {
   display: none !important;
   visibility: hidden !important;

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -20,6 +20,22 @@ const AD_TILE_SELECTOR = [
 ].join(',');
 
 let adSlotObserver = null;
+let shortsObserver = null;
+
+const SHORTS_RENDERER_SELECTOR = [
+  'ytlr-reel-shelf-renderer',
+  'ytd-reel-shelf-renderer',
+  'ytlr-reel-shelf-view-model',
+  'ytd-reel-shelf-view-model',
+  'ytlr-shorts-lockup-view-model',
+  'ytd-shorts-lockup-view-model',
+  'ytlr-reel-item-renderer',
+  'ytd-reel-item-renderer',
+  '[data-renderer-type="reelShelfRenderer"]',
+  '[data-renderer-type="reelShelfViewModel"]',
+  '[data-renderer-type="shortsShelfRenderer"]',
+  '[data-renderer-type="shortsLockupViewModel"]'
+].join(',');
 
 function findAdTile(adRenderer) {
   const semanticTile = adRenderer.closest(AD_TILE_SELECTOR);
@@ -71,9 +87,7 @@ function processAddedNode(node) {
 function startAdSlotObserver() {
   if (adSlotObserver || !document.body) return;
 
-  document
-    .querySelectorAll(AD_RENDERER_SELECTOR)
-    .forEach(hideAdRenderer);
+  document.querySelectorAll(AD_RENDERER_SELECTOR).forEach(hideAdRenderer);
 
   adSlotObserver = new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
@@ -99,10 +113,7 @@ function stopAdSlotObserver() {
 
 function syncAdblockStyles() {
   const enabled = Boolean(configRead('enableAdBlock'));
-  document.documentElement.classList.toggle(
-    'ytaf-adblock-enabled',
-    enabled
-  );
+  document.documentElement.classList.toggle('ytaf-adblock-enabled', enabled);
 
   if (enabled) {
     startAdSlotObserver();
@@ -111,8 +122,60 @@ function syncAdblockStyles() {
   }
 }
 
+function hideShortsRenderer(node) {
+  if (!node || node.nodeType !== 1) return;
+  node.classList.add('ytaf-hidden-shorts');
+}
+
+function processShortsNode(node) {
+  if (!node || node.nodeType !== 1) return;
+
+  if (node.matches(SHORTS_RENDERER_SELECTOR)) {
+    hideShortsRenderer(node);
+  }
+  node.querySelectorAll(SHORTS_RENDERER_SELECTOR).forEach(hideShortsRenderer);
+}
+
+function startShortsObserver() {
+  if (shortsObserver || !document.body) return;
+
+  processShortsNode(document.body);
+  shortsObserver = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      mutation.addedNodes.forEach(processShortsNode);
+    });
+  });
+  shortsObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+function stopShortsObserver() {
+  if (shortsObserver) {
+    shortsObserver.disconnect();
+    shortsObserver = null;
+  }
+
+  document.querySelectorAll('.ytaf-hidden-shorts').forEach((node) => {
+    node.classList.remove('ytaf-hidden-shorts');
+  });
+}
+
+function syncShortsVisibility() {
+  const enabled = Boolean(configRead('enableShorts'));
+  document.documentElement.classList.toggle('ytaf-shorts-disabled', !enabled);
+
+  if (enabled) {
+    stopShortsObserver();
+  } else {
+    startShortsObserver();
+  }
+}
+
 export function userScriptStartAdBlock() {
   syncAdblockStyles();
+}
+
+export function userScriptStartShorts() {
+  syncShortsVisibility();
 }
 
 document.addEventListener(
@@ -120,6 +183,9 @@ document.addEventListener(
   (event) => {
     if (event.detail && event.detail.key === 'enableAdBlock') {
       syncAdblockStyles();
+    }
+    if (event.detail && event.detail.key === 'enableShorts') {
+      syncShortsVisibility();
     }
   },
   true
@@ -234,16 +300,14 @@ const origParse = JSON.parse;
 JSON.parse = function () {
   const r = origParse.apply(this, arguments);
 
-  if (!configRead('enableAdBlock')) {
-    return r;
-  }
+  if (configRead('enableAdBlock')) {
+    if (stripYouTubeAds(r)) {
+      console.log('Adblock Removed !');
+    }
 
-  if (stripYouTubeAds(r)) {
-    console.log('Adblock Removed !');
-  }
-
-  if (stripAdditionalYouTubeAds(r)) {
-    console.log('Adblock Removed additional renderers !');
+    if (stripAdditionalYouTubeAds(r)) {
+      console.log('Adblock Removed additional renderers !');
+    }
   }
 
   return r;

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -127,12 +127,20 @@ function hideShortsRenderer(node) {
   node.classList.add('ytaf-hidden-shorts');
 }
 
-function processShortsNode(node) {
+function syncShortsNode(node) {
   if (!node || node.nodeType !== 1) return;
 
   if (node.matches(SHORTS_RENDERER_SELECTOR)) {
     hideShortsRenderer(node);
+  } else {
+    node.classList.remove('ytaf-hidden-shorts');
   }
+}
+
+function processShortsNode(node) {
+  if (!node || node.nodeType !== 1) return;
+
+  syncShortsNode(node);
   node.querySelectorAll(SHORTS_RENDERER_SELECTOR).forEach(hideShortsRenderer);
 }
 
@@ -142,10 +150,19 @@ function startShortsObserver() {
   processShortsNode(document.body);
   shortsObserver = new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
-      mutation.addedNodes.forEach(processShortsNode);
+      if (mutation.type === 'attributes') {
+        syncShortsNode(mutation.target);
+      } else {
+        mutation.addedNodes.forEach(processShortsNode);
+      }
     });
   });
-  shortsObserver.observe(document.body, { childList: true, subtree: true });
+  shortsObserver.observe(document.body, {
+    attributes: true,
+    attributeFilter: ['data-renderer-type'],
+    childList: true,
+    subtree: true
+  });
 }
 
 function stopShortsObserver() {

--- a/webapp/src/config.js
+++ b/webapp/src/config.js
@@ -12,7 +12,8 @@ const defaultConfig = {
   enableSponsorBlockFiller: false,
   enableSponsorBlockHook: false,
   enableAutoLogin: true,
-  enableReturnYouTubeDislike: true
+  enableReturnYouTubeDislike: true,
+  enableShorts: true
 };
 
 let localConfig;

--- a/webapp/src/languages/de.js
+++ b/webapp/src/languages/de.js
@@ -5,6 +5,7 @@ export default {
     autoLogin: 'Kontoauswahl automatisch überspringen',
     sponsorblock: 'SponsorBlock aktivieren',
     ryd: 'Dislike-Zahlen anzeigen',
+    shorts: 'YouTube Shorts aktivieren',
     sponsor: 'Sponsor-Segmente überspringen',
     intro: 'Intro überspringen',
     outro: 'Outro überspringen',

--- a/webapp/src/languages/en.js
+++ b/webapp/src/languages/en.js
@@ -5,6 +5,7 @@ export default {
     autoLogin: 'Automatically skip account selection',
     sponsorblock: 'Enable SponsorBlock',
     ryd: 'Show dislike counts',
+    shorts: 'Enable YouTube Shorts',
     sponsor: 'Skip Sponsor Segments',
     intro: 'Skip Intro Segments',
     outro: 'Skip Outro Segments',

--- a/webapp/src/languages/es.js
+++ b/webapp/src/languages/es.js
@@ -1,7 +1,7 @@
 export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
-    adblock: 'Bloquear anuncios', autoLogin: 'Omitir automáticamente la selección de cuenta', sponsorblock: 'Activar SponsorBlock', ryd: 'Mostrar recuento de no me gusta',
+    adblock: 'Bloquear anuncios', autoLogin: 'Omitir automáticamente la selección de cuenta', sponsorblock: 'Activar SponsorBlock', ryd: 'Mostrar recuento de no me gusta', shorts: 'Activar YouTube Shorts',
     sponsor: 'Saltar segmentos patrocinados', intro: 'Saltar introducciones', outro: 'Saltar finales',
     interaction: 'Saltar recordatorios de suscripción y me gusta', selfpromo: 'Saltar autopromoción',
     musicOfftopic: 'Saltar música/fuera de tema', preview: 'Saltar avances/resúmenes',

--- a/webapp/src/languages/fr.js
+++ b/webapp/src/languages/fr.js
@@ -1,7 +1,7 @@
 export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
-    adblock: 'Bloquer les publicités', autoLogin: 'Ignorer automatiquement le choix du compte', sponsorblock: 'Activer SponsorBlock', ryd: 'Afficher le nombre de dislikes',
+    adblock: 'Bloquer les publicités', autoLogin: 'Ignorer automatiquement le choix du compte', sponsorblock: 'Activer SponsorBlock', ryd: 'Afficher le nombre de dislikes', shorts: 'Activer YouTube Shorts',
     sponsor: 'Ignorer les segments sponsorisés', intro: 'Ignorer les introductions', outro: 'Ignorer les conclusions',
     interaction: 'Ignorer les rappels d’abonnement et de mention J’aime', selfpromo: 'Ignorer l’autopromotion',
     musicOfftopic: 'Ignorer la musique/hors sujet', preview: 'Ignorer les aperçus/récapitulatifs',

--- a/webapp/src/languages/it.js
+++ b/webapp/src/languages/it.js
@@ -5,6 +5,7 @@ export default {
     autoLogin: 'Salta automaticamente la selezione account',
     sponsorblock: 'Attiva SponsorBlock',
     ryd: 'Mostra numero di non mi piace',
+    shorts: 'Attiva YouTube Shorts',
     sponsor: 'Salta segmenti sponsor',
     intro: 'Salta intro',
     outro: 'Salta outro',

--- a/webapp/src/languages/nl.js
+++ b/webapp/src/languages/nl.js
@@ -1,7 +1,7 @@
 export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
-    adblock: 'Advertenties blokkeren', autoLogin: 'Accountselectie automatisch overslaan', sponsorblock: 'SponsorBlock inschakelen', ryd: 'Aantal dislikes tonen',
+    adblock: 'Advertenties blokkeren', autoLogin: 'Accountselectie automatisch overslaan', sponsorblock: 'SponsorBlock inschakelen', ryd: 'Aantal dislikes tonen', shorts: 'YouTube Shorts inschakelen',
     sponsor: 'Sponsorsegmenten overslaan', intro: 'Introsegmenten overslaan', outro: 'Outrosegmenten overslaan',
     interaction: 'Abonnements- en likeherinneringen overslaan', selfpromo: 'Zelfpromotie overslaan',
     musicOfftopic: 'Muziek/off-topic overslaan', preview: 'Vooruitblik/samenvatting overslaan',

--- a/webapp/src/languages/pl.js
+++ b/webapp/src/languages/pl.js
@@ -1,7 +1,7 @@
 export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
-    adblock: 'Blokuj reklamy', autoLogin: 'Automatycznie pomijaj wybór konta', sponsorblock: 'Włącz SponsorBlock', ryd: 'Pokaż liczbę negatywnych ocen',
+    adblock: 'Blokuj reklamy', autoLogin: 'Automatycznie pomijaj wybór konta', sponsorblock: 'Włącz SponsorBlock', ryd: 'Pokaż liczbę negatywnych ocen', shorts: 'Włącz YouTube Shorts',
     sponsor: 'Pomiń segmenty sponsorskie', intro: 'Pomiń intro', outro: 'Pomiń zakończenie',
     interaction: 'Pomiń przypomnienia o subskrypcji i polubieniu', selfpromo: 'Pomiń autopromocję',
     musicOfftopic: 'Pomiń muzykę/treści nie na temat', preview: 'Pomiń zapowiedź/podsumowanie',

--- a/webapp/src/languages/pt.js
+++ b/webapp/src/languages/pt.js
@@ -1,7 +1,7 @@
 export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
-    adblock: 'Bloquear anúncios', autoLogin: 'Ignorar automaticamente a seleção de conta', sponsorblock: 'Ativar SponsorBlock', ryd: 'Mostrar contagem de não gostei',
+    adblock: 'Bloquear anúncios', autoLogin: 'Ignorar automaticamente a seleção de conta', sponsorblock: 'Ativar SponsorBlock', ryd: 'Mostrar contagem de não gostei', shorts: 'Ativar YouTube Shorts',
     sponsor: 'Pular segmentos patrocinados', intro: 'Pular introduções', outro: 'Pular encerramentos',
     interaction: 'Pular lembretes de inscrição e curtir', selfpromo: 'Pular autopromoção',
     musicOfftopic: 'Pular música/fora do assunto', preview: 'Pular prévias/resumos',

--- a/webapp/src/ui.js
+++ b/webapp/src/ui.js
@@ -201,6 +201,14 @@ export function userScriptStartUI() {
   );
   uiContainer.appendChild(
     checkboxTools.add(
+      '__shorts',
+      text('shorts'),
+      configRead('enableShorts'),
+      callbackConfig('enableShorts')
+    )
+  );
+  uiContainer.appendChild(
+    checkboxTools.add(
       '__sponsorblock',
       text('sponsorblock'),
       configRead('enableSponsorBlock'),


### PR DESCRIPTION
## Summary
- add a persistent `Enable YouTube Shorts` setting to the GREEN-button extras menu
- keep Shorts enabled by default for existing and new users
- hide Shorts shelves and lockups from the Home Screen when disabled
- update live-rendered content as YouTube navigates without affecting direct Shorts playback
- add localized labels and document the feature

## Validation
- changed implementation and localization files pass ESLint
- changed files pass Prettier
- production webapp build succeeds

Fixes #44