### PR TITLE
Add configurable default startup page

### DIFF
--- a/webapp/src/adblock-main.js
+++ b/webapp/src/adblock-main.js
@@ -6,7 +6,7 @@ import './domrect-polyfill';
 import './json-stringify-hook';
 import './ui.js';
 
-import { handleLaunch, waitForChildAdd } from './utils';
+import { handleInitialLaunch, handleLaunch, waitForChildAdd } from './utils';
 import { configRead } from './config.js';
 import { userScriptStartUI } from './ui.js';
 import { userScriptStartAdBlock } from './adblock.js';
@@ -95,6 +95,12 @@ function startDebugOverlay() {
 
 export async function startUserScript() {
   console.info('[ytaf] startUserScript begin');
+
+  try {
+    handleInitialLaunch();
+  } catch (err) {
+    console.warn('[ytaf] Failed to apply startup page:', err);
+  }
 
   try {
     userScriptStartUI();

--- a/webapp/src/choiceTools.css
+++ b/webapp/src/choiceTools.css
@@ -1,0 +1,38 @@
+.choice-wrapper {
+  cursor: pointer;
+  margin: 3px 0;
+  padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 34px;
+  box-sizing: border-box;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.choice-wrapper.ytaf-focused {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(68, 204, 102, 0.82);
+  box-shadow: 0 0 0 2px rgba(68, 204, 102, 0.2);
+  transform: translateX(2px);
+}
+
+.choice-wrapper .desc {
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.88rem;
+}
+
+.choice-wrapper .choice-value {
+  flex: 0 0 auto;
+  min-width: 120px;
+  padding: 5px 10px;
+  text-align: center;
+  color: #fff;
+  background: rgba(68, 204, 102, 0.22);
+  border: 1px solid rgba(68, 204, 102, 0.68);
+  border-radius: 5px;
+  font-size: 0.78rem;
+}

--- a/webapp/src/choiceTools.js
+++ b/webapp/src/choiceTools.js
@@ -1,0 +1,67 @@
+import './choiceTools.css';
+
+let choiceTabIndex = 100;
+const choices = {};
+
+function render(control) {
+  const entry = choices[control.id];
+  if (!entry) return;
+
+  const selected = entry.options.find((option) => option.value === entry.value);
+  control.textContent = selected ? selected.label : entry.value;
+}
+
+function cycle(name) {
+  const control = document.querySelector('#' + name);
+  const entry = choices[name];
+  if (!control || !entry || entry.options.length === 0) return;
+
+  const currentIndex = entry.options.findIndex(
+    (option) => option.value === entry.value
+  );
+  const nextIndex = (currentIndex + 1) % entry.options.length;
+  entry.value = entry.options[nextIndex].value;
+  render(control);
+  if (entry.callback) entry.callback(entry.value);
+}
+
+function add(name, label, value, options, callback = null) {
+  const wrapper = document.createElement('div');
+  wrapper.classList.add('choice-wrapper');
+
+  const description = document.createElement('div');
+  description.classList.add('desc');
+  description.textContent = label;
+
+  const control = document.createElement('div');
+  control.id = name;
+  control.classList.add('choice-value');
+  control.tabIndex = choiceTabIndex;
+  control.dataset.ytafControl = 'choice';
+
+  choices[name] = { value, options, callback };
+  render(control);
+
+  wrapper.appendChild(description);
+  wrapper.appendChild(control);
+  wrapper.addEventListener(
+    'click',
+    (event) => {
+      if (Number(wrapper.dataset.ytafIgnoreClickUntil || 0) > Date.now()) {
+        delete wrapper.dataset.ytafIgnoreClickUntil;
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      cycle(name);
+    },
+    true
+  );
+  control.addEventListener('focus', () => wrapper.classList.add('ytaf-focused'));
+  control.addEventListener('blur', () => wrapper.classList.remove('ytaf-focused'));
+
+  choiceTabIndex += 1;
+  return wrapper;
+}
+
+export const choiceTools = { add, cycle };

--- a/webapp/src/config.js
+++ b/webapp/src/config.js
@@ -1,6 +1,7 @@
 const CONFIG_KEY = 'ytaf-configuration-cobalt-adfree-v2';
 const defaultConfig = {
   enableAdBlock: true,
+  startupPage: 'home',
   enableSponsorBlock: true,
   enableSponsorBlockSponsor: true,
   enableSponsorBlockIntro: true,

--- a/webapp/src/languages/de.js
+++ b/webapp/src/languages/de.js
@@ -2,6 +2,11 @@ export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
     adblock: 'Werbung blockieren',
+    startupPage: 'Startseite',
+    startupPageHome: 'Home',
+    startupPageSubscriptions: 'Abos',
+    startupPageShorts: 'Shorts',
+    startupPageLibrary: 'Mediathek',
     autoLogin: 'Kontoauswahl automatisch überspringen',
     sponsorblock: 'SponsorBlock aktivieren',
     ryd: 'Dislike-Zahlen anzeigen',

--- a/webapp/src/languages/en.js
+++ b/webapp/src/languages/en.js
@@ -2,6 +2,11 @@ export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
     adblock: 'Enable AdBlocking',
+    startupPage: 'Startup page',
+    startupPageHome: 'Home',
+    startupPageSubscriptions: 'Subscriptions',
+    startupPageShorts: 'Shorts',
+    startupPageLibrary: 'Library',
     autoLogin: 'Automatically skip account selection',
     sponsorblock: 'Enable SponsorBlock',
     ryd: 'Show dislike counts',

--- a/webapp/src/languages/es.js
+++ b/webapp/src/languages/es.js
@@ -1,7 +1,7 @@
 export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
-    adblock: 'Bloquear anuncios', autoLogin: 'Omitir automáticamente la selección de cuenta', sponsorblock: 'Activar SponsorBlock', ryd: 'Mostrar recuento de no me gusta',
+    adblock: 'Bloquear anuncios', startupPage: 'Página de inicio', startupPageHome: 'Inicio', startupPageSubscriptions: 'Suscripciones', startupPageShorts: 'Shorts', startupPageLibrary: 'Biblioteca', autoLogin: 'Omitir automáticamente la selección de cuenta', sponsorblock: 'Activar SponsorBlock', ryd: 'Mostrar recuento de no me gusta',
     sponsor: 'Saltar segmentos patrocinados', intro: 'Saltar introducciones', outro: 'Saltar finales',
     interaction: 'Saltar recordatorios de suscripción y me gusta', selfpromo: 'Saltar autopromoción',
     musicOfftopic: 'Saltar música/fuera de tema', preview: 'Saltar avances/resúmenes',

--- a/webapp/src/languages/fr.js
+++ b/webapp/src/languages/fr.js
@@ -1,7 +1,7 @@
 export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
-    adblock: 'Bloquer les publicités', autoLogin: 'Ignorer automatiquement le choix du compte', sponsorblock: 'Activer SponsorBlock', ryd: 'Afficher le nombre de dislikes',
+    adblock: 'Bloquer les publicités', startupPage: 'Page de démarrage', startupPageHome: 'Accueil', startupPageSubscriptions: 'Abonnements', startupPageShorts: 'Shorts', startupPageLibrary: 'Bibliothèque', autoLogin: 'Ignorer automatiquement le choix du compte', sponsorblock: 'Activer SponsorBlock', ryd: 'Afficher le nombre de dislikes',
     sponsor: 'Ignorer les segments sponsorisés', intro: 'Ignorer les introductions', outro: 'Ignorer les conclusions',
     interaction: 'Ignorer les rappels d’abonnement et de mention J’aime', selfpromo: 'Ignorer l’autopromotion',
     musicOfftopic: 'Ignorer la musique/hors sujet', preview: 'Ignorer les aperçus/récapitulatifs',

--- a/webapp/src/languages/it.js
+++ b/webapp/src/languages/it.js
@@ -2,6 +2,11 @@ export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
     adblock: 'Blocca pubblicità',
+    startupPage: 'Pagina iniziale',
+    startupPageHome: 'Home',
+    startupPageSubscriptions: 'Iscrizioni',
+    startupPageShorts: 'Shorts',
+    startupPageLibrary: 'Raccolta',
     autoLogin: 'Salta automaticamente la selezione account',
     sponsorblock: 'Attiva SponsorBlock',
     ryd: 'Mostra numero di non mi piace',

--- a/webapp/src/languages/nl.js
+++ b/webapp/src/languages/nl.js
@@ -1,7 +1,7 @@
 export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
-    adblock: 'Advertenties blokkeren', autoLogin: 'Accountselectie automatisch overslaan', sponsorblock: 'SponsorBlock inschakelen', ryd: 'Aantal dislikes tonen',
+    adblock: 'Advertenties blokkeren', startupPage: 'Startpagina', startupPageHome: 'Home', startupPageSubscriptions: 'Abonnementen', startupPageShorts: 'Shorts', startupPageLibrary: 'Bibliotheek', autoLogin: 'Accountselectie automatisch overslaan', sponsorblock: 'SponsorBlock inschakelen', ryd: 'Aantal dislikes tonen',
     sponsor: 'Sponsorsegmenten overslaan', intro: 'Introsegmenten overslaan', outro: 'Outrosegmenten overslaan',
     interaction: 'Abonnements- en likeherinneringen overslaan', selfpromo: 'Zelfpromotie overslaan',
     musicOfftopic: 'Muziek/off-topic overslaan', preview: 'Vooruitblik/samenvatting overslaan',

--- a/webapp/src/languages/pl.js
+++ b/webapp/src/languages/pl.js
@@ -1,7 +1,7 @@
 export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
-    adblock: 'Blokuj reklamy', autoLogin: 'Automatycznie pomijaj wybór konta', sponsorblock: 'Włącz SponsorBlock', ryd: 'Pokaż liczbę negatywnych ocen',
+    adblock: 'Blokuj reklamy', startupPage: 'Strona startowa', startupPageHome: 'Główna', startupPageSubscriptions: 'Subskrypcje', startupPageShorts: 'Shorts', startupPageLibrary: 'Biblioteka', autoLogin: 'Automatycznie pomijaj wybór konta', sponsorblock: 'Włącz SponsorBlock', ryd: 'Pokaż liczbę negatywnych ocen',
     sponsor: 'Pomiń segmenty sponsorskie', intro: 'Pomiń intro', outro: 'Pomiń zakończenie',
     interaction: 'Pomiń przypomnienia o subskrypcji i polubieniu', selfpromo: 'Pomiń autopromocję',
     musicOfftopic: 'Pomiń muzykę/treści nie na temat', preview: 'Pomiń zapowiedź/podsumowanie',

--- a/webapp/src/languages/pt.js
+++ b/webapp/src/languages/pt.js
@@ -1,7 +1,7 @@
 export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
-    adblock: 'Bloquear anúncios', autoLogin: 'Ignorar automaticamente a seleção de conta', sponsorblock: 'Ativar SponsorBlock', ryd: 'Mostrar contagem de não gostei',
+    adblock: 'Bloquear anúncios', startupPage: 'Página inicial', startupPageHome: 'Início', startupPageSubscriptions: 'Inscrições', startupPageShorts: 'Shorts', startupPageLibrary: 'Biblioteca', autoLogin: 'Ignorar automaticamente a seleção de conta', sponsorblock: 'Ativar SponsorBlock', ryd: 'Mostrar contagem de não gostei',
     sponsor: 'Pular segmentos patrocinados', intro: 'Pular introduções', outro: 'Pular encerramentos',
     interaction: 'Pular lembretes de inscrição e curtir', selfpromo: 'Pular autopromoção',
     musicOfftopic: 'Pular música/fora do assunto', preview: 'Pular prévias/resumos',

--- a/webapp/src/ui.js
+++ b/webapp/src/ui.js
@@ -7,6 +7,7 @@ import './ui.css';
 
 import { configRead, configWrite } from './config.js';
 import { checkboxTools } from './checkboxTools.js';
+import { choiceTools } from './choiceTools.js';
 import { text as languageText } from './languages/index.js';
 import { sponsorBlockCategoryColors } from './sponsorblock-categories.js';
 import {
@@ -181,6 +182,20 @@ export function userScriptStartUI() {
       text('adblock'),
       configRead('enableAdBlock'),
       callbackConfig('enableAdBlock')
+    )
+  );
+  uiContainer.appendChild(
+    choiceTools.add(
+      '__startup_page',
+      text('startupPage'),
+      configRead('startupPage'),
+      [
+        { value: 'home', label: text('startupPageHome') },
+        { value: 'subscriptions', label: text('startupPageSubscriptions') },
+        { value: 'shorts', label: text('startupPageShorts') },
+        { value: 'library', label: text('startupPageLibrary') }
+      ],
+      callbackConfig('startupPage')
     )
   );
   uiContainer.appendChild(

--- a/webapp/src/ui.js
+++ b/webapp/src/ui.js
@@ -522,7 +522,11 @@ export function userScriptStartUI() {
           if (wrapper) {
             wrapper.dataset.ytafIgnoreClickUntil = String(Date.now() + 1000);
           }
-          checkboxTools.toggleCheck(focusedElement.id);
+          if (focusedElement.dataset.ytafControl === 'choice') {
+            choiceTools.cycle(focusedElement.id);
+          } else {
+            checkboxTools.toggleCheck(focusedElement.id);
+          }
         }
         return false;
       }

--- a/webapp/src/utils.js
+++ b/webapp/src/utils.js
@@ -3,14 +3,22 @@ import { configRead } from './config.js';
 
 const YT_BASE_URL = new URL('https://www.youtube.com/tv#/');
 const CONTENT_INTENT_REGEX = /^.+(?=Content)/g;
-const STARTUP_PAGE_BROWSE_IDS = {
-  subscriptions: 'FEsubscriptions',
-  shorts: 'FEshorts',
-  library: 'FElibrary'
+const STARTUP_PAGE_ENDPOINTS = {
+  subscriptions: { browseId: 'FEsubscriptions' },
+  shorts: {
+    url: '/youtubei/v1/reel/reel_item_watch',
+    iconType: 'YOUTUBE_SHORTS_FILL_24',
+    title: 'Shorts'
+  },
+  library: { browseId: 'FElibrary' }
 };
+const STARTUP_PAGE_RETRY_INTERVAL_MS = 250;
+const STARTUP_PAGE_MAX_ATTEMPTS = 80;
+let startupPageApplied = false;
 
 export function getStartupPageUrl(page = configRead('startupPage')) {
-  const browseId = STARTUP_PAGE_BROWSE_IDS[page];
+  const browseId = STARTUP_PAGE_ENDPOINTS[page] &&
+    STARTUP_PAGE_ENDPOINTS[page].browseId;
   return browseId
     ? `${YT_BASE_URL.origin}/tv#/browse/${browseId}`
     : YT_BASE_URL.toString();
@@ -76,7 +84,7 @@ export function handleLaunch(params) {
     }
     default: {
       console.info('Default launch');
-      href = getStartupPageUrl();
+      href = YT_BASE_URL.toString();
     }
   }
 
@@ -89,14 +97,53 @@ export function handleInitialLaunch() {
     return;
   }
 
-  const href = getStartupPageUrl();
-  if (href === YT_BASE_URL.toString()) return;
+  const page = configRead('startupPage');
+  const startupEndpoint = STARTUP_PAGE_ENDPOINTS[page];
+  if (!startupEndpoint || startupPageApplied) return;
 
-  const currentHash = window.location.hash;
-  if (currentHash === '' || currentHash === '#' || currentHash === '#/') {
-    console.info('Applying configured startup page');
-    window.location.href = href;
-  }
+  let attempts = 0;
+  const applyStartupPage = () => {
+    attempts += 1;
+
+    const renderers = document.querySelectorAll('ytlr-guide-entry-renderer');
+    for (let index = 0; index < renderers.length; index += 1) {
+      const renderer = renderers[index];
+      const instance = renderer.__instance;
+      const props = instance && instance.props;
+      const endpoint = props && props.data && props.data.navigationEndpoint;
+      const rendererBrowseId = endpoint && endpoint.browseEndpoint
+        && endpoint.browseEndpoint.browseId;
+      const rendererUrl = endpoint && endpoint.commandMetadata
+        && endpoint.commandMetadata.webCommandMetadata
+        && endpoint.commandMetadata.webCommandMetadata.url;
+      const rendererIconType = props && props.data && props.data.icon
+        && props.data.icon.iconType;
+      const rendererTitle = props && props.data && props.data.formattedTitle
+        && props.data.formattedTitle.simpleText;
+      const endpointMatches = startupEndpoint.browseId
+        ? rendererBrowseId === startupEndpoint.browseId
+        : rendererUrl === startupEndpoint.url
+          || rendererIconType === startupEndpoint.iconType
+          || rendererTitle === startupEndpoint.title;
+
+      if (!endpointMatches || typeof props.onSelect !== 'function') {
+        continue;
+      }
+
+      startupPageApplied = true;
+      console.info(`Applying configured startup page: ${page}`);
+      props.onSelect();
+      return;
+    }
+
+    if (attempts < STARTUP_PAGE_MAX_ATTEMPTS) {
+      window.setTimeout(applyStartupPage, STARTUP_PAGE_RETRY_INTERVAL_MS);
+    } else {
+      console.warn(`Configured startup page was not found: ${page}`);
+    }
+  };
+
+  applyStartupPage();
 }
 
 /**

--- a/webapp/src/utils.js
+++ b/webapp/src/utils.js
@@ -1,6 +1,20 @@
 // const YT_BASE_URL = new URL('https://www.youtube.com/tv#/');
+import { configRead } from './config.js';
+
 const YT_BASE_URL = new URL('https://www.youtube.com/tv#/');
 const CONTENT_INTENT_REGEX = /^.+(?=Content)/g;
+const STARTUP_PAGE_BROWSE_IDS = {
+  subscriptions: 'FEsubscriptions',
+  shorts: 'FEshorts',
+  library: 'FElibrary'
+};
+
+export function getStartupPageUrl(page = configRead('startupPage')) {
+  const browseId = STARTUP_PAGE_BROWSE_IDS[page];
+  return browseId
+    ? `${YT_BASE_URL.origin}/tv#/browse/${browseId}`
+    : YT_BASE_URL.toString();
+}
 
 export function extractLaunchParams() {
   if (window.launchParams) {
@@ -62,11 +76,27 @@ export function handleLaunch(params) {
     }
     default: {
       console.info('Default launch');
-      href = YT_BASE_URL.toString();
+      href = getStartupPageUrl();
     }
   }
 
   window.location.href = href;
+}
+
+export function handleInitialLaunch() {
+  const params = extractLaunchParams();
+  if (params.target !== undefined || params.contentTarget !== undefined) {
+    return;
+  }
+
+  const href = getStartupPageUrl();
+  if (href === YT_BASE_URL.toString()) return;
+
+  const currentHash = window.location.hash;
+  if (currentHash === '' || currentHash === '#' || currentHash === '#/') {
+    console.info('Applying configured startup page');
+    window.location.href = href;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- add a configuration option for Home, Subscriptions, Shorts, or Library
- navigate through YouTube TV's live guide renderer callbacks instead of rewriting the URL
- match Subscriptions and Library by browse ID and Shorts by its reel endpoint/icon metadata
- preserve content-target and voice launches

## Testing

- built the webapp successfully with webpack
- packaged and validated a non-debug webOS IPK
- physically tested on an LG webOS TV
- confirmed Home, Subscriptions, Shorts, and Library all work after a cold launch
- confirmed the selection persists across reboot

## Notes

YouTube TV handles these destinations internally. The implementation waits for the matching guide renderer and invokes its existing onSelect callback, avoiding synthetic key events and fragile hash routing.
