### PR TITLE
Fix compressed Cobalt runtime packaging

### DIFF
--- a/.github/workflows/build-release-ipks.yml
+++ b/.github/workflows/build-release-ipks.yml
@@ -85,6 +85,7 @@ jobs:
             squashfs-tools \
             rename \
             findutils \
+            lz4 \
             xz-utils \
             python3
 

--- a/Makefile
+++ b/Makefile
@@ -398,12 +398,20 @@ ifneq ("$(PACKAGE_NAME_TARGET)","$(PACKAGE_NAME_OFFICIAL)")
 	find $(WORKDIR)/ipk -name '*.bak' -delete
 endif
 
-	libcobalt=$$(find $(WORKDIR)/ipk -name libcobalt.so -print -quit); \
-	if test -z "$$libcobalt"; then \
-		libcobalt="$(WORKDIR)/ipk/content/app/cobalt/lib/libcobalt.so"; \
-		mkdir -p "$$(dirname "$$libcobalt")"; \
-	fi; \
-	cp $(WORKDIR)/cobalt/libcobalt.so "$$libcobalt"
+	libcobalt_lz4=$$(find $(WORKDIR)/ipk -name libcobalt.lz4 -print -quit); \
+	if test -n "$$libcobalt_lz4"; then \
+		command -v lz4 >/dev/null 2>&1 || { echo "lz4 is required for compressed Cobalt packages"; exit 1; }; \
+		lz4 -q -f --content-size -9 "$(WORKDIR)/cobalt/libcobalt.so" "$$libcobalt_lz4" && \
+			lz4 -q -t "$$libcobalt_lz4"; \
+	else \
+		grep -q -- '--evergreen_lite' $(WORKDIR)/ipk/switches || echo " --evergreen_lite" >> $(WORKDIR)/ipk/switches; \
+		libcobalt=$$(find $(WORKDIR)/ipk -name libcobalt.so -print -quit); \
+		if test -z "$$libcobalt"; then \
+			libcobalt="$(WORKDIR)/ipk/content/app/cobalt/lib/libcobalt.so"; \
+			mkdir -p "$$(dirname "$$libcobalt")"; \
+		fi; \
+		cp $(WORKDIR)/cobalt/libcobalt.so "$$libcobalt"; \
+	fi
 	cp -r $(WORKDIR)/cobalt/content $(WORKDIR)/ipk/content/app/cobalt
 	mkdir -p $(WORKDIR)/ipk/content/app/cobalt/content/web/adblock
 	mkdir -p $(WORKDIR)/ipk/content/app/cobalt/content/web/adblock

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ speeds range from 0.25× to 2×.
 * Required tools:
 
 ```sh
-sudo apt install jq git sed binutils squashfs-tools rename findutils xz-utils
+sudo apt install jq git sed binutils squashfs-tools rename findutils xz-utils lz4
 ```
 
 The standard patched app uses `youtube.leanback.v4` and therefore replaces the
@@ -277,6 +277,10 @@ Patch your official YouTube IPK:
 ```sh
 make package PACKAGE=./your-tv-youtube.ipk
 ```
+
+For source packages with `libcobalt.lz4`, the build replaces that file and adds
+the content-size metadata required by newer LG loaders. The replacement Cobalt
+runtime must match the starter's Starboard API.
 
 For maintainers, a plain `make` builds the current standard package from the
 private `youtube-official-1.1.5.tar.gz` base and the tested

--- a/scripts/verify-ipk-container.py
+++ b/scripts/verify-ipk-container.py
@@ -8,10 +8,15 @@ import io
 from pathlib import Path
 import tarfile
 
-
 AR_MAGIC = b"!<arch>\n"
 AR_HEADER_SIZE = 60
 EXPECTED_MEMBERS = ("debian-binary", "control.tar.gz", "data.tar.gz")
+LZ4_FRAME_MAGIC = b"\x04\x22\x4d\x18"
+LZ4_FLAGS_OFFSET = len(LZ4_FRAME_MAGIC)
+LZ4_CONTENT_SIZE_OFFSET = LZ4_FLAGS_OFFSET + 2
+LZ4_CONTENT_SIZE_LENGTH = 8
+LZ4_CONTENT_SIZE_FLAG = 0x08
+LZ4_CONTENT_SIZE_HEADER_LENGTH = LZ4_CONTENT_SIZE_OFFSET + LZ4_CONTENT_SIZE_LENGTH
 
 
 def parse_decimal(field: bytes, label: str) -> int:
@@ -63,7 +68,28 @@ def read_members(package: Path) -> dict[str, tuple[int, bytes]]:
 def verify_tar(name: str, contents: bytes) -> None:
     try:
         with tarfile.open(fileobj=io.BytesIO(contents), mode="r:gz") as archive:
-            archive.getmembers()
+            members = archive.getmembers()
+            if name == "data.tar.gz":
+                for member in members:
+                    if not member.isfile() or Path(member.name).name != "libcobalt.lz4":
+                        continue
+                    runtime = archive.extractfile(member)
+                    if runtime is None:
+                        raise ValueError(f"Could not read {member.name}")
+                    header = runtime.read(LZ4_CONTENT_SIZE_HEADER_LENGTH)
+                    if (
+                        len(header) < LZ4_CONTENT_SIZE_OFFSET
+                        or header[:LZ4_FLAGS_OFFSET] != LZ4_FRAME_MAGIC
+                    ):
+                        raise ValueError(f"Invalid {member.name}: invalid LZ4 frame")
+                    if not header[LZ4_FLAGS_OFFSET] & LZ4_CONTENT_SIZE_FLAG:
+                        raise ValueError(
+                            f"Invalid {member.name}: missing LZ4 content size"
+                        )
+                    if len(header) < LZ4_CONTENT_SIZE_HEADER_LENGTH:
+                        raise ValueError(
+                            f"Invalid {member.name}: truncated LZ4 content size"
+                        )
     except (tarfile.TarError, OSError) as error:
         raise ValueError(f"Invalid {name}: {error}") from error
 


### PR DESCRIPTION
## Problem

Newer LG YouTube packages load `libcobalt.lz4`. A replacement frame without content-size metadata is rejected by the loader:

> Content size must be present in the LZ4 frame header

The IPK installs and shows its splash screen, then exits.

## Change

- replace `libcobalt.lz4` when the source IPK uses a compressed runtime
- compress with `lz4 --content-size -9` and test the result
- reject packaged runtimes missing the content-size flag
- add `lz4` to the build dependencies

The existing uncompressed `libcobalt.so` path is unchanged.

## Validation

- the original 1.2.104 package fails verification
- repaired and Makefile-built SB16 packages pass `lz4 -t` and package verification
- installed and launched on an LG 55NANO82T3B, firmware 33.22.75, SDK 10.2.2
- the app remained running

No Cobalt binaries are included. The runtime must still match the starter’s Starboard API.

Fixes #54
Related: #10