### PR TITLE
Integrate PR #51 menu scrolling with current main

### DIFF
--- a/webapp/src/sponsored-qr-code-ui.js
+++ b/webapp/src/sponsored-qr-code-ui.js
@@ -24,6 +24,8 @@ export function userScriptStartSponsoredQrCodeUI() {
     return;
   }
 
+  const menuContent =
+    uiContainer.querySelector('.ytaf-ui-content') || uiContainer;
   const control = checkboxTools.add(
     '__sponsored_qr_code_block',
     getLabel(),
@@ -37,9 +39,9 @@ export function userScriptStartSponsoredQrCodeUI() {
     (startupControl && startupControl.parentElement) ||
     (adblockControl && adblockControl.parentElement);
 
-  if (anchor && anchor.parentElement === uiContainer) {
-    uiContainer.insertBefore(control, anchor.nextSibling);
+  if (anchor && anchor.parentElement === menuContent) {
+    menuContent.insertBefore(control, anchor.nextSibling);
   } else {
-    uiContainer.appendChild(control);
+    menuContent.appendChild(control);
   }
 }

--- a/webapp/src/ui.css
+++ b/webapp/src/ui.css
@@ -31,10 +31,14 @@
 }
 
 .ytaf-ui-container div.center {
+  position: relative;
+  z-index: 2;
   text-align: left;
   margin-bottom: 12px;
   padding-bottom: 12px;
+  background: #05080c;
   border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 12px 0 #05080c;
 }
 
 .ytaf-ui-container div.small {

--- a/webapp/src/ui.js
+++ b/webapp/src/ui.js
@@ -31,6 +31,7 @@ export function userScriptStartUI() {
   const PLAYBACK_RATES = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
   let lastGreenKeyAt = 0;
   let currentFocusIndex = -1;
+  let menuScrollFrame = null;
 
   function getDirectionFromEvent(evt) {
     const key = (evt.key || '').toLowerCase();
@@ -106,24 +107,29 @@ export function userScriptStartUI() {
     if (!item || !uiContainer.contains(item)) return;
 
     const visibleMargin = 24;
-    let itemTop = 0;
-    let current = item;
-    while (current && current !== uiContainer) {
-      itemTop += current.offsetTop || 0;
-      current = current.offsetParent;
-    }
+    const row = item.parentElement && uiContainer.contains(item.parentElement)
+      ? item.parentElement
+      : item;
+    const containerRect = uiContainer.getBoundingClientRect();
+    const itemRect = row.getBoundingClientRect();
+    const visibleTop = containerRect.top + visibleMargin;
+    const visibleBottom = containerRect.bottom - visibleMargin;
 
-    const itemBottom = itemTop + (item.offsetHeight || 0);
-    const visibleTop = uiContainer.scrollTop + visibleMargin;
-    const visibleBottom =
-      uiContainer.scrollTop + uiContainer.clientHeight - visibleMargin;
-
-    if (itemTop < visibleTop) {
-      uiContainer.scrollTop = Math.max(0, itemTop - visibleMargin);
-    } else if (itemBottom > visibleBottom) {
-      uiContainer.scrollTop =
-        itemBottom - uiContainer.clientHeight + visibleMargin;
+    if (itemRect.top < visibleTop) {
+      uiContainer.scrollTop += itemRect.top - visibleTop;
+    } else if (itemRect.bottom > visibleBottom) {
+      uiContainer.scrollTop += itemRect.bottom - visibleBottom;
     }
+  }
+
+  function queueMenuItemScroll(item) {
+    if (menuScrollFrame !== null) {
+      window.cancelAnimationFrame(menuScrollFrame);
+    }
+    menuScrollFrame = window.requestAnimationFrame(() => {
+      menuScrollFrame = null;
+      scrollMenuItemIntoView(item);
+    });
   }
 
   function moveFocus(dir) {
@@ -152,7 +158,7 @@ export function userScriptStartUI() {
     const nextItem = focusableItems[currentFocusIndex];
     if (nextItem) {
       nextItem.focus();
-      scrollMenuItemIntoView(nextItem);
+      queueMenuItemScroll(nextItem);
       lastTabIndex = nextItem.tabIndex;
     }
   }
@@ -164,9 +170,9 @@ export function userScriptStartUI() {
   uiContainer.setAttribute('tabindex', 0);
   uiContainer.addEventListener(
     'focus',
-    () => {
+    (event) => {
       console.info('uiContainer focused!');
-      const focusedElement = document.activeElement;
+      const focusedElement = event.target;
       if (
         focusedElement &&
         focusedElement !== uiContainer &&
@@ -174,7 +180,7 @@ export function userScriptStartUI() {
         focusedElement.tabIndex > 0
       ) {
         lastTabIndex = focusedElement.tabIndex;
-        scrollMenuItemIntoView(focusedElement);
+        queueMenuItemScroll(focusedElement);
       }
     },
     true
@@ -406,7 +412,7 @@ export function userScriptStartUI() {
 
     if (target) {
       target.focus();
-      scrollMenuItemIntoView(target);
+      queueMenuItemScroll(target);
       currentFocusIndex = focusableItems.indexOf(target);
       if (target.tabIndex !== null && target.tabIndex > 0) {
         lastTabIndex = target.tabIndex;
@@ -469,6 +475,10 @@ export function userScriptStartUI() {
 
   function closeContainer() {
     console.info('Container: Hiding!');
+    if (menuScrollFrame !== null) {
+      window.cancelAnimationFrame(menuScrollFrame);
+      menuScrollFrame = null;
+    }
     if (focusGuardFrame !== null) {
       window.cancelAnimationFrame(focusGuardFrame);
       focusGuardFrame = null;

--- a/webapp/src/ui.js
+++ b/webapp/src/ui.js
@@ -34,6 +34,9 @@ export function userScriptStartUI() {
   let menuScrollFrame = null;
   let menuOffset = 0;
   let menuContent = null;
+  let heldDirection = null;
+  let heldDirectionAt = 0;
+  let directionMoveFrame = null;
 
   function getDirectionFromEvent(evt) {
     const key = (evt.key || '').toLowerCase();
@@ -176,6 +179,35 @@ export function userScriptStartUI() {
       queueMenuItemScroll(nextItem);
       lastTabIndex = nextItem.tabIndex;
     }
+  }
+
+  function queueDirectionMove(direction) {
+    if (directionMoveFrame !== null) return;
+
+    const focusBeforeEvent = document.activeElement;
+    directionMoveFrame = window.requestAnimationFrame(() => {
+      directionMoveFrame = null;
+      const focusAfterEvent = document.activeElement;
+
+      // Some Cobalt versions perform native spatial navigation before the
+      // cancelled key event settles. Accept that move instead of adding one.
+      if (
+        focusAfterEvent &&
+        focusAfterEvent !== focusBeforeEvent &&
+        uiContainer.contains(focusAfterEvent) &&
+        focusAfterEvent.tabIndex > 0
+      ) {
+        const focusableItems = Array.from(
+          uiContainer.querySelectorAll('[tabindex]')
+        ).filter((item) => item.tabIndex > 0);
+        currentFocusIndex = focusableItems.indexOf(focusAfterEvent);
+        lastTabIndex = focusAfterEvent.tabIndex;
+        queueMenuItemScroll(focusAfterEvent);
+        return;
+      }
+
+      moveFocus(direction);
+    });
   }
 
   const uiContainer = document.createElement('div');
@@ -509,9 +541,14 @@ export function userScriptStartUI() {
       window.cancelAnimationFrame(focusGuardFrame);
       focusGuardFrame = null;
     }
+    if (directionMoveFrame !== null) {
+      window.cancelAnimationFrame(directionMoveFrame);
+      directionMoveFrame = null;
+    }
     uiContainer.style.display = 'none';
     uiContainer.style.visibility = 'hidden';
     uiContainer.style.pointerEvents = 'none';
+    heldDirection = null;
     const menuFocus = document.activeElement;
     if (menuFocus && uiContainer.contains(menuFocus) && typeof menuFocus.blur === 'function') {
       menuFocus.blur();
@@ -537,6 +574,16 @@ export function userScriptStartUI() {
   const eventHandler = (evt) => {
     const menuOpen = isContainerOpen();
     const focusInsideMenu = menuOpen && menuHasFocus();
+    const eventDirection = menuOpen ? getDirectionFromEvent(evt) : null;
+
+    if (evt.type === 'keyup' && eventDirection) {
+      if (heldDirection === eventDirection) {
+        heldDirection = null;
+      }
+      evt.preventDefault();
+      evt.stopPropagation();
+      return false;
+    }
 
     if (evt.type === 'keydown' && menuOpen) {
       if (!focusInsideMenu) {
@@ -545,11 +592,20 @@ export function userScriptStartUI() {
         captureMenuFocus();
       }
 
-      const direction = getDirectionFromEvent(evt);
+      const direction = eventDirection;
       if (direction) {
         evt.preventDefault();
         evt.stopPropagation();
-        moveFocus(direction);
+        const now = Date.now();
+        if (
+          evt.repeat ||
+          (heldDirection === direction && now - heldDirectionAt < 400)
+        ) {
+          return false;
+        }
+        heldDirection = direction;
+        heldDirectionAt = now;
+        queueDirectionMove(direction);
         return false;
       }
 

--- a/webapp/src/ui.js
+++ b/webapp/src/ui.js
@@ -388,6 +388,9 @@ export function userScriptStartUI() {
   menuViewport.classList.add('ytaf-ui-viewport');
   menuViewport.style.position = 'relative';
   menuViewport.style.overflow = 'hidden';
+  menuViewport.style.boxSizing = 'border-box';
+  menuViewport.style.paddingLeft = '4px';
+  menuViewport.style.paddingRight = '4px';
   menuViewport.appendChild(menuContent);
   uiContainer.appendChild(menuViewport);
 

--- a/webapp/src/ui.js
+++ b/webapp/src/ui.js
@@ -448,7 +448,7 @@ export function userScriptStartUI() {
       background: '#05080c',
       color: '#ffffff',
       border: '6px solid #37ff77',
-      borderRadius: '0',
+      borderRadius: '12px',
       padding: '24px',
       fontSize: '22px',
       lineHeight: '1.25',

--- a/webapp/src/ui.js
+++ b/webapp/src/ui.js
@@ -32,6 +32,8 @@ export function userScriptStartUI() {
   let lastGreenKeyAt = 0;
   let currentFocusIndex = -1;
   let menuScrollFrame = null;
+  let menuOffset = 0;
+  let menuContent = null;
 
   function getDirectionFromEvent(evt) {
     const key = (evt.key || '').toLowerCase();
@@ -104,7 +106,11 @@ export function userScriptStartUI() {
   }
 
   function scrollMenuItemIntoView(item) {
-    if (!item || !uiContainer.contains(item)) return;
+    if (!item || !menuContent || !uiContainer.contains(item)) return;
+
+    // Cobalt resets an overflow container's scrollTop after programmatic focus.
+    // Keep the viewport fixed and move its inner panel instead.
+    uiContainer.scrollTop = 0;
 
     const visibleMargin = 24;
     const row = item.parentElement && uiContainer.contains(item.parentElement)
@@ -116,10 +122,15 @@ export function userScriptStartUI() {
     const visibleBottom = containerRect.bottom - visibleMargin;
 
     if (itemRect.top < visibleTop) {
-      uiContainer.scrollTop += itemRect.top - visibleTop;
+      menuOffset += itemRect.top - visibleTop;
     } else if (itemRect.bottom > visibleBottom) {
-      uiContainer.scrollTop += itemRect.bottom - visibleBottom;
+      menuOffset += itemRect.bottom - visibleBottom;
     }
+
+    const viewportHeight = Math.max(0, uiContainer.clientHeight - 48);
+    const maximumOffset = Math.max(0, menuContent.scrollHeight - viewportHeight);
+    menuOffset = Math.max(0, Math.min(maximumOffset, menuOffset));
+    menuContent.style.top = `${-menuOffset}px`;
   }
 
   function queueMenuItemScroll(item) {
@@ -333,6 +344,15 @@ export function userScriptStartUI() {
   );
   uiContainer.appendChild(sponsorBlock);
 
+  menuContent = document.createElement('div');
+  menuContent.classList.add('ytaf-ui-content');
+  menuContent.style.position = 'relative';
+  menuContent.style.top = '0';
+  while (uiContainer.firstChild) {
+    menuContent.appendChild(uiContainer.firstChild);
+  }
+  uiContainer.appendChild(menuContent);
+
   (document.body || document.documentElement).appendChild(uiContainer);
 
   let latestFocus = null;
@@ -380,7 +400,7 @@ export function userScriptStartUI() {
       maxWidth: '80vw',
       maxHeight: '80vh',
       boxSizing: 'border-box',
-      overflow: 'auto',
+      overflow: 'hidden',
       zIndex: '2147483647',
       pointerEvents: 'auto',
       background: '#05080c',
@@ -432,6 +452,8 @@ export function userScriptStartUI() {
         : null;
     suspendSpatialNavigation();
     applyVisibleContainerStyles();
+    menuOffset = 0;
+    menuContent.style.top = '0';
     uiContainer.scrollTop = 0;
 
     setTimeout(() => {

--- a/webapp/src/ui.js
+++ b/webapp/src/ui.js
@@ -34,6 +34,7 @@ export function userScriptStartUI() {
   let menuScrollFrame = null;
   let menuOffset = 0;
   let menuContent = null;
+  let menuViewport = null;
   let heldDirection = null;
   let heldDirectionAt = 0;
   let directionMoveFrame = null;
@@ -109,24 +110,20 @@ export function userScriptStartUI() {
   }
 
   function scrollMenuItemIntoView(item) {
-    if (!item || !menuContent || !uiContainer.contains(item)) return;
+    if (!item || !menuContent || !menuViewport || !uiContainer.contains(item)) return;
 
     // Cobalt resets an overflow container's scrollTop after programmatic focus.
     // Keep the viewport fixed and move its inner panel instead.
     uiContainer.scrollTop = 0;
 
-    const visibleMargin = 24;
+    const visibleMargin = 8;
     const row = item.parentElement && uiContainer.contains(item.parentElement)
       ? item.parentElement
       : item;
-    const containerRect = uiContainer.getBoundingClientRect();
-    const titleRect = divTitle.getBoundingClientRect();
+    const viewportRect = menuViewport.getBoundingClientRect();
     const itemRect = row.getBoundingClientRect();
-    const visibleTop = Math.max(
-      containerRect.top + visibleMargin,
-      titleRect.bottom + 12
-    );
-    const visibleBottom = containerRect.bottom - visibleMargin;
+    const visibleTop = viewportRect.top + visibleMargin;
+    const visibleBottom = viewportRect.bottom - visibleMargin;
 
     if (itemRect.top < visibleTop) {
       menuOffset += itemRect.top - visibleTop;
@@ -387,7 +384,12 @@ export function userScriptStartUI() {
   while (uiContainer.children.length > 1) {
     menuContent.appendChild(uiContainer.children[1]);
   }
-  uiContainer.appendChild(menuContent);
+  menuViewport = document.createElement('div');
+  menuViewport.classList.add('ytaf-ui-viewport');
+  menuViewport.style.position = 'relative';
+  menuViewport.style.overflow = 'hidden';
+  menuViewport.appendChild(menuContent);
+  uiContainer.appendChild(menuViewport);
 
   (document.body || document.documentElement).appendChild(uiContainer);
 
@@ -434,6 +436,7 @@ export function userScriptStartUI() {
       bottom: 'auto',
       width: '720px',
       maxWidth: '80vw',
+      height: '80vh',
       maxHeight: '80vh',
       boxSizing: 'border-box',
       overflow: 'hidden',
@@ -450,6 +453,12 @@ export function userScriptStartUI() {
       animation: 'none',
       boxShadow: '0 0 0 9999px rgba(0,0,0,0.55)'
     });
+
+    const viewportHeight = Math.max(
+      0,
+      uiContainer.clientHeight - 48 - divTitle.offsetHeight - 12
+    );
+    menuViewport.style.height = `${viewportHeight}px`;
   }
 
   function focusMenuItem(preferredTabIndex = lastTabIndex) {

--- a/webapp/src/ui.js
+++ b/webapp/src/ui.js
@@ -117,8 +117,12 @@ export function userScriptStartUI() {
       ? item.parentElement
       : item;
     const containerRect = uiContainer.getBoundingClientRect();
+    const titleRect = divTitle.getBoundingClientRect();
     const itemRect = row.getBoundingClientRect();
-    const visibleTop = containerRect.top + visibleMargin;
+    const visibleTop = Math.max(
+      containerRect.top + visibleMargin,
+      titleRect.bottom + 12
+    );
     const visibleBottom = containerRect.bottom - visibleMargin;
 
     if (itemRect.top < visibleTop) {
@@ -127,7 +131,7 @@ export function userScriptStartUI() {
       menuOffset += itemRect.bottom - visibleBottom;
     }
 
-    const viewportHeight = Math.max(0, uiContainer.clientHeight - 48);
+    const viewportHeight = Math.max(0, visibleBottom - visibleTop);
     const maximumOffset = Math.max(0, menuContent.scrollHeight - viewportHeight);
     menuOffset = Math.max(0, Math.min(maximumOffset, menuOffset));
     menuContent.style.top = `${-menuOffset}px`;
@@ -348,8 +352,8 @@ export function userScriptStartUI() {
   menuContent.classList.add('ytaf-ui-content');
   menuContent.style.position = 'relative';
   menuContent.style.top = '0';
-  while (uiContainer.firstChild) {
-    menuContent.appendChild(uiContainer.firstChild);
+  while (uiContainer.children.length > 1) {
+    menuContent.appendChild(uiContainer.children[1]);
   }
   uiContainer.appendChild(menuContent);
 

--- a/webapp/src/ui.js
+++ b/webapp/src/ui.js
@@ -102,6 +102,30 @@ export function userScriptStartUI() {
     return true;
   }
 
+  function scrollMenuItemIntoView(item) {
+    if (!item || !uiContainer.contains(item)) return;
+
+    const visibleMargin = 24;
+    let itemTop = 0;
+    let current = item;
+    while (current && current !== uiContainer) {
+      itemTop += current.offsetTop || 0;
+      current = current.offsetParent;
+    }
+
+    const itemBottom = itemTop + (item.offsetHeight || 0);
+    const visibleTop = uiContainer.scrollTop + visibleMargin;
+    const visibleBottom =
+      uiContainer.scrollTop + uiContainer.clientHeight - visibleMargin;
+
+    if (itemTop < visibleTop) {
+      uiContainer.scrollTop = Math.max(0, itemTop - visibleMargin);
+    } else if (itemBottom > visibleBottom) {
+      uiContainer.scrollTop =
+        itemBottom - uiContainer.clientHeight + visibleMargin;
+    }
+  }
+
   function moveFocus(dir) {
     const focusableItems = Array.from(
       uiContainer.querySelectorAll('[tabindex]')
@@ -128,6 +152,7 @@ export function userScriptStartUI() {
     const nextItem = focusableItems[currentFocusIndex];
     if (nextItem) {
       nextItem.focus();
+      scrollMenuItemIntoView(nextItem);
       lastTabIndex = nextItem.tabIndex;
     }
   }
@@ -149,6 +174,7 @@ export function userScriptStartUI() {
         focusedElement.tabIndex > 0
       ) {
         lastTabIndex = focusedElement.tabIndex;
+        scrollMenuItemIntoView(focusedElement);
       }
     },
     true
@@ -380,6 +406,7 @@ export function userScriptStartUI() {
 
     if (target) {
       target.focus();
+      scrollMenuItemIntoView(target);
       currentFocusIndex = focusableItems.indexOf(target);
       if (target.tabIndex !== null && target.tabIndex > 0) {
         lastTabIndex = target.tabIndex;
@@ -399,6 +426,7 @@ export function userScriptStartUI() {
         : null;
     suspendSpatialNavigation();
     applyVisibleContainerStyles();
+    uiContainer.scrollTop = 0;
 
     setTimeout(() => {
       focusMenuItem(1);


### PR DESCRIPTION
Integrates #51 on top of the current main after #49/#50.

Changes:
- preserve the startup-page choice control and its Enter/OK handling from #50
- apply #51's fixed-header scroll viewport and single-step remote navigation changes
- keep the sponsored QR toggle from #49 inside the new `.ytaf-ui-content` scroll container
- retain the existing CI test step added with #49

The branch starts from GitHub's clean merge of current main and the original #51 head, then adds only the QR viewport integration fix.