### PR TITLE
Integrate PR #52 Shorts visibility fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ and potentially other PJTR/k7lp devices. It uses the stock PJTR app id,
 * Return YouTube Dislike support
 * Automatic account selection on startup
 * Playback speed support
-* Optional Shorts visibility
+* Optional Shorts visibility across the sidebar, home page and browse sections
 * Optional autostart integration
 * Installable as patched `.ipk` package
 
@@ -41,6 +41,10 @@ The configuration screen can be opened with the **GREEN** button on the LG remot
 While a video is playing, press **1** to decrease the playback speed or **3** to
 increase it. Press **0** to toggle subtitles on or off. The available playback
 speeds range from 0.25× to 2×.
+
+When **Enable YouTube Shorts** is disabled, Shorts navigation entries and Shorts
+content are hidden from the sidebar, home page, search results and other browse
+sections. Direct Shorts playback remains available when opened explicitly.
 
 ## Requirements
 

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -52,8 +52,11 @@ const SHORTS_LINK_SELECTOR = [
   'a[aria-label="Shorts"]',
   'a[title="Shorts"]',
   '[role="link"][aria-label="Shorts"]',
+  '[role="link"][title="Shorts"]',
   '[role="menuitem"][aria-label="Shorts"]',
-  '[role="treeitem"][aria-label="Shorts"]'
+  '[role="menuitem"][title="Shorts"]',
+  '[role="treeitem"][aria-label="Shorts"]',
+  '[role="treeitem"][title="Shorts"]'
 ].join(',');
 const SHORTS_ITEM_CONTAINER_SELECTOR = [
   'ytlr-guide-entry-renderer',
@@ -154,10 +157,10 @@ function syncAdblockStyles() {
 }
 
 function findShortsContainer(node) {
-  if (node.getAttribute('data-browse-id') === 'FEshorts') return node;
-
   const semanticContainer = node.closest(SHORTS_ITEM_CONTAINER_SELECTOR);
   if (semanticContainer) return semanticContainer;
+
+  if (node.getAttribute('data-browse-id') === 'FEshorts') return node;
 
   let container = node;
   let item = node;

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -195,13 +195,14 @@ function collectShortsAncestors(node, targets) {
 
   let ancestor = node.parentElement;
   while (ancestor) {
+    const isShelfHeader = ancestor.matches(SHORTS_SHELF_HEADER_SELECTOR);
     if (
       ancestor.classList.contains('ytaf-hidden-shorts') ||
-      ancestor.matches(SHORTS_SHELF_HEADER_SELECTOR) ||
+      isShelfHeader ||
       ancestor.matches(SHORTS_ITEM_RESCAN_SELECTOR)
     ) {
       targets.add(ancestor);
-      return;
+      if (!isShelfHeader) return;
     }
     ancestor = ancestor.parentElement;
   }

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -286,6 +286,7 @@ function startShortsObserver() {
       'data-id',
       'aria-label',
       'title',
+      'role',
       'href',
       'data-uri',
       'data-href'

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -36,6 +36,7 @@ const SHORTS_RENDERER_SELECTOR = [
   '[data-renderer-type="shortsShelfRenderer"]',
   '[data-renderer-type="shortsLockupViewModel"]'
 ].join(',');
+const SHORTS_SHELF_HEADER_SELECTOR = 'ytlr-shelf-header, ytd-shelf-header';
 const SHORTS_LINK_SELECTOR = [
   'a[href^="/shorts"]',
   'a[href^="/feed/shorts"]',
@@ -62,6 +63,10 @@ const SHORTS_LABEL_SELECTOR = '[aria-label], [title]';
 const SHORTS_MARKER_SELECTOR =
   '[data-browse-id], [data-section-id], [data-nav-id], [data-id]';
 const SHORTS_ITEM_CONTAINER_SELECTOR = [
+  'ytlr-shelf-renderer',
+  'ytd-shelf-renderer',
+  'ytlr-section-list-renderer',
+  'ytd-section-list-renderer',
   'ytlr-guide-entry-renderer',
   'ytd-guide-entry-renderer',
   'ytlr-rich-item-renderer',
@@ -226,6 +231,23 @@ function isShortsLink(node) {
   );
 }
 
+function isShortsShelfHeader(node) {
+  if (!node || node.nodeType !== 1) return false;
+
+  const tagName = node.tagName.toLowerCase();
+  return (
+    (tagName === 'ytlr-shelf-header' || tagName === 'ytd-shelf-header') &&
+    node.textContent.trim().toLowerCase() === 'shorts'
+  );
+}
+
+function findShortsShelfContainer(node) {
+  const shelfContainer = node.closest(
+    'ytlr-shelf-renderer, ytd-shelf-renderer, ytlr-section-list-renderer, ytd-section-list-renderer'
+  );
+  return shelfContainer || node;
+}
+
 function isWatchPath(value) {
   if (!value) return false;
 
@@ -258,10 +280,18 @@ function syncShortsNode(node) {
   if (!node || node.nodeType !== 1) return;
 
   const isRenderer = node.matches(SHORTS_RENDERER_SELECTOR);
+  const isShelfHeader = isShortsShelfHeader(node);
   const isLink = isShortsLink(node);
-  const target = isLink ? findShortsContainer(node) : node;
+  const target = isShelfHeader
+    ? findShortsShelfContainer(node)
+    : isLink
+      ? findShortsContainer(node)
+      : node;
 
-  target.classList.toggle('ytaf-hidden-shorts', isRenderer || isLink);
+  target.classList.toggle(
+    'ytaf-hidden-shorts',
+    isRenderer || isShelfHeader || isLink
+  );
 }
 
 function processShortsNode(node) {
@@ -272,7 +302,7 @@ function processShortsNode(node) {
   syncShortsNode(node);
   node
     .querySelectorAll(
-      `${SHORTS_RENDERER_SELECTOR}, ${SHORTS_LINK_SELECTOR}, ${SHORTS_LABEL_SELECTOR}, ${SHORTS_MARKER_SELECTOR}`
+      `${SHORTS_RENDERER_SELECTOR}, ${SHORTS_SHELF_HEADER_SELECTOR}, ${SHORTS_LINK_SELECTOR}, ${SHORTS_LABEL_SELECTOR}, ${SHORTS_MARKER_SELECTOR}`
     )
     .forEach(syncShortsNode);
 }
@@ -309,6 +339,7 @@ function startShortsObserver() {
       'data-href'
     ],
     childList: true,
+    characterData: true,
     subtree: true
   });
 }

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -232,7 +232,7 @@ function isShortsLink(node) {
     node.hasAttribute('data-id');
   const isGuideNavigation = Boolean(
     node.closest(
-      'ytlr-guide-entry-renderer, ytd-guide-entry-renderer, [role="tree"], [role="menubar"], [role="navigation"]'
+      'ytlr-guide-entry-renderer, ytd-guide-entry-renderer, [role="tree"], [role="menu"], [role="menubar"], [role="navigation"]'
     )
   );
   return (

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -163,6 +163,15 @@ function findShortsContainer(node) {
   return node;
 }
 
+function syncShortsAncestor(node) {
+  if (!node || node.nodeType !== 1) return;
+
+  const ancestor =
+    node.closest('.ytaf-hidden-shorts') ||
+    node.closest(SHORTS_ITEM_CONTAINER_SELECTOR);
+  if (ancestor) processShortsNode(ancestor);
+}
+
 function isShortsLink(node) {
   if (!node || node.nodeType !== 1) return false;
 
@@ -215,13 +224,7 @@ function syncShortsNode(node) {
 
   const isRenderer = node.matches(SHORTS_RENDERER_SELECTOR);
   const isLink = isShortsLink(node);
-  const isNavigationNode =
-    node.tagName === 'A' ||
-    node.hasAttribute('data-uri') ||
-    node.hasAttribute('data-href') ||
-    node.hasAttribute('data-browse-id');
-  const target =
-    isRenderer || !isNavigationNode ? node : findShortsContainer(node);
+  const target = isLink && !isRenderer ? findShortsContainer(node) : node;
 
   target.classList.toggle('ytaf-hidden-shorts', isRenderer || isLink);
 }
@@ -247,6 +250,7 @@ function startShortsObserver() {
         syncShortsNode(mutation.target);
       } else {
         processShortsNode(mutation.target);
+        syncShortsAncestor(mutation.target);
         mutation.addedNodes.forEach(processShortsNode);
       }
     });

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -220,9 +220,15 @@ function isShortsLink(node) {
     node.hasAttribute('data-section-id') ||
     node.hasAttribute('data-nav-id') ||
     node.hasAttribute('data-id');
+  const isGuideNavigation = Boolean(
+    node.closest(
+      'ytlr-guide-entry-renderer, ytd-guide-entry-renderer, [role="tree"], [role="menubar"], [role="navigation"]'
+    )
+  );
   return (
     isNavigationNode &&
     ((label.toLowerCase() === 'shorts' &&
+      isGuideNavigation &&
       ![href, uri, dataHref].some(isWatchPath)) ||
       browseId === 'FEshorts' ||
       sectionId.toLowerCase() === 'shorts' ||
@@ -313,6 +319,7 @@ function startShortsObserver() {
 
   processShortsNode(document.body);
   shortsObserver = new MutationObserver((mutations) => {
+    const targets = new Set();
     mutations.forEach((mutation) => {
       const target =
         mutation.type === 'characterData'
@@ -320,13 +327,15 @@ function startShortsObserver() {
           : mutation.target;
       if (!target) return;
 
-      if (mutation.type === 'attributes') {
-        syncShortsNode(target);
-        syncShortsAncestor(target);
-      } else {
+      targets.add(target);
+      mutation.addedNodes.forEach((node) => {
+        if (node.nodeType === 1) targets.add(node);
+      });
+    });
+    targets.forEach((target) => {
+      if (target.parentElement) {
         processShortsNode(target);
         syncShortsAncestor(target);
-        mutation.addedNodes.forEach(processShortsNode);
       }
     });
   });

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -155,9 +155,11 @@ function findShortsContainer(node) {
   if (semanticContainer) return semanticContainer;
 
   let container = node;
+  let item = node;
   for (let depth = 0; depth < 8 && container.parentElement; depth += 1) {
+    item = container;
     container = container.parentElement;
-    if (container.children.length > 1) return container;
+    if (container.children.length > 1) return item;
   }
 
   return node;
@@ -254,6 +256,7 @@ function startShortsObserver() {
     mutations.forEach((mutation) => {
       if (mutation.type === 'attributes') {
         syncShortsNode(mutation.target);
+        syncShortsAncestor(mutation.target);
       } else {
         processShortsNode(mutation.target);
         syncShortsAncestor(mutation.target);

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -181,7 +181,7 @@ function findShortsContainer(node) {
   return node;
 }
 
-function syncShortsAncestor(node) {
+function collectShortsAncestors(node, targets) {
   if (!node || node.nodeType !== 1) return;
 
   let ancestor = node.parentElement;
@@ -190,7 +190,7 @@ function syncShortsAncestor(node) {
       ancestor.classList.contains('ytaf-hidden-shorts') ||
       ancestor.matches(SHORTS_ITEM_CONTAINER_SELECTOR)
     ) {
-      processShortsNode(ancestor);
+      targets.add(ancestor);
     }
     ancestor = ancestor.parentElement;
   }
@@ -328,14 +328,17 @@ function startShortsObserver() {
       if (!target) return;
 
       targets.add(target);
+      collectShortsAncestors(target, targets);
       mutation.addedNodes.forEach((node) => {
-        if (node.nodeType === 1) targets.add(node);
+        if (node.nodeType === 1) {
+          targets.add(node);
+          collectShortsAncestors(node, targets);
+        }
       });
     });
     targets.forEach((target) => {
       if (target.parentElement) {
         processShortsNode(target);
-        syncShortsAncestor(target);
       }
     });
   });

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -166,10 +166,16 @@ function findShortsContainer(node) {
 function syncShortsAncestor(node) {
   if (!node || node.nodeType !== 1) return;
 
-  const ancestor =
-    node.closest('.ytaf-hidden-shorts') ||
-    node.closest(SHORTS_ITEM_CONTAINER_SELECTOR);
-  if (ancestor) processShortsNode(ancestor);
+  let ancestor = node.parentElement;
+  for (let depth = 0; ancestor && depth < 8; depth += 1) {
+    if (
+      ancestor.classList.contains('ytaf-hidden-shorts') ||
+      ancestor.matches(SHORTS_ITEM_CONTAINER_SELECTOR)
+    ) {
+      processShortsNode(ancestor);
+    }
+    ancestor = ancestor.parentElement;
+  }
 }
 
 function isShortsLink(node) {
@@ -224,7 +230,7 @@ function syncShortsNode(node) {
 
   const isRenderer = node.matches(SHORTS_RENDERER_SELECTOR);
   const isLink = isShortsLink(node);
-  const target = isLink && !isRenderer ? findShortsContainer(node) : node;
+  const target = isLink ? findShortsContainer(node) : node;
 
   target.classList.toggle('ytaf-hidden-shorts', isRenderer || isLink);
 }

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -48,7 +48,12 @@ const SHORTS_LINK_SELECTOR = [
   '[data-browse-id="FEshorts"]',
   '[data-section-id="shorts"]',
   '[data-nav-id="shorts"]',
-  '[data-id="shorts"]'
+  '[data-id="shorts"]',
+  'a[aria-label="Shorts"]',
+  'a[title="Shorts"]',
+  '[role="link"][aria-label="Shorts"]',
+  '[role="menuitem"][aria-label="Shorts"]',
+  '[role="treeitem"][aria-label="Shorts"]'
 ].join(',');
 const SHORTS_ITEM_CONTAINER_SELECTOR = [
   'ytlr-guide-entry-renderer',

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -63,10 +63,6 @@ const SHORTS_LABEL_SELECTOR = '[aria-label], [title]';
 const SHORTS_MARKER_SELECTOR =
   '[data-browse-id], [data-section-id], [data-nav-id], [data-id]';
 const SHORTS_ITEM_CONTAINER_SELECTOR = [
-  'ytlr-shelf-renderer',
-  'ytd-shelf-renderer',
-  'ytlr-section-list-renderer',
-  'ytd-section-list-renderer',
   'ytlr-guide-entry-renderer',
   'ytd-guide-entry-renderer',
   'ytlr-rich-item-renderer',

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -63,13 +63,6 @@ const SHORTS_ITEM_CONTAINER_SELECTOR = [
   '[role="treeitem"]',
   '[role="menuitem"]'
 ].join(',');
-const SHORTS_RESPONSE_KEYS = [
-  'reelShelfRenderer',
-  'reelShelfViewModel',
-  'shortsShelfRenderer',
-  'shortsLockupViewModel'
-];
-
 function findAdTile(adRenderer) {
   const semanticTile = adRenderer.closest(AD_TILE_SELECTOR);
   if (semanticTile) return semanticTile;
@@ -217,82 +210,6 @@ function isShortsPath(value) {
   );
 }
 
-function getShortsLinkNode(value) {
-  if (!value || typeof value !== 'object') return null;
-
-  const endpoints = [
-    value.navigationEndpoint,
-    value.onSelectCommand,
-    value.command,
-    value.tileRenderer?.onSelectCommand,
-    value.richItemRenderer?.content?.shortsLockupViewModel?.onTap
-  ];
-  return endpoints.find((endpoint) => {
-    const path = endpoint?.commandMetadata?.webCommandMetadata?.url;
-    const browseId = endpoint?.browseEndpoint?.browseId;
-    return isShortsPath(path) || browseId === 'FEshorts';
-  });
-}
-
-function isShortsResponseEntry(value) {
-  if (!value || typeof value !== 'object') return false;
-
-  const content =
-    value.richItemRenderer?.content ||
-    value.tileRenderer?.content ||
-    value.content;
-  return Boolean(
-    SHORTS_RESPONSE_KEYS.some((key) =>
-      Object.prototype.hasOwnProperty.call(value, key)
-    ) ||
-    content?.shortsLockupViewModel ||
-    content?.reelItemRenderer ||
-    getShortsLinkNode(value)
-  );
-}
-
-function stripShortsFromBrowseResponse(value, depth = 0) {
-  if (!value || typeof value !== 'object' || depth > 32) return false;
-
-  let changed = false;
-  if (Array.isArray(value)) {
-    for (let index = value.length - 1; index >= 0; index -= 1) {
-      if (isShortsResponseEntry(value[index])) {
-        value.splice(index, 1);
-        changed = true;
-      } else {
-        changed =
-          stripShortsFromBrowseResponse(value[index], depth + 1) || changed;
-      }
-    }
-    return changed;
-  }
-
-  Object.keys(value).forEach((key) => {
-    if (SHORTS_RESPONSE_KEYS.includes(key)) {
-      delete value[key];
-      changed = true;
-      return;
-    }
-
-    changed = stripShortsFromBrowseResponse(value[key], depth + 1) || changed;
-  });
-
-  return changed;
-}
-
-function isBrowseResponse(value) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
-
-  return (
-    !value.videoDetails &&
-    !value.streamingData &&
-    (value.contents ||
-      value.onResponseReceivedActions ||
-      value.onResponseReceivedEndpoints)
-  );
-}
-
 function syncShortsNode(node) {
   if (!node || node.nodeType !== 1) return;
 
@@ -316,6 +233,7 @@ function processShortsNode(node) {
   node
     .querySelectorAll(`${SHORTS_RENDERER_SELECTOR}, ${SHORTS_LINK_SELECTOR}`)
     .forEach(syncShortsNode);
+  node.querySelectorAll('.ytaf-hidden-shorts').forEach(syncShortsNode);
 }
 
 function startShortsObserver() {
@@ -510,14 +428,6 @@ JSON.parse = function () {
     if (stripAdditionalYouTubeAds(r)) {
       console.log('Adblock Removed additional renderers !');
     }
-  }
-
-  if (
-    !configRead('enableShorts') &&
-    isBrowseResponse(r) &&
-    stripShortsFromBrowseResponse(r)
-  ) {
-    console.log('Shorts disabled: removed browse renderers !');
   }
 
   return r;

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -229,11 +229,12 @@ function syncShortsNode(node) {
 function processShortsNode(node) {
   if (!node || node.nodeType !== 1) return;
 
+  // Clear stale classes first; current Shorts matches must win below.
+  node.querySelectorAll('.ytaf-hidden-shorts').forEach(syncShortsNode);
   syncShortsNode(node);
   node
     .querySelectorAll(`${SHORTS_RENDERER_SELECTOR}, ${SHORTS_LINK_SELECTOR}`)
     .forEach(syncShortsNode);
-  node.querySelectorAll('.ytaf-hidden-shorts').forEach(syncShortsNode);
 }
 
 function startShortsObserver() {

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -36,6 +36,39 @@ const SHORTS_RENDERER_SELECTOR = [
   '[data-renderer-type="shortsShelfRenderer"]',
   '[data-renderer-type="shortsLockupViewModel"]'
 ].join(',');
+const SHORTS_LINK_SELECTOR = [
+  'a[href^="/shorts"]',
+  'a[href^="/feed/shorts"]',
+  'a[href^="https://www.youtube.com/shorts"]',
+  'a[href^="https://www.youtube.com/feed/shorts"]',
+  '[data-uri^="/shorts"]',
+  '[data-uri^="/feed/shorts"]',
+  '[data-href^="/shorts"]',
+  '[data-href^="/feed/shorts"]',
+  '[data-browse-id="FEshorts"]',
+  '[data-section-id="shorts"]',
+  '[data-nav-id="shorts"]',
+  '[data-id="shorts"]'
+].join(',');
+const SHORTS_ITEM_CONTAINER_SELECTOR = [
+  'ytlr-guide-entry-renderer',
+  'ytd-guide-entry-renderer',
+  'ytlr-rich-item-renderer',
+  'ytd-rich-item-renderer',
+  'ytlr-grid-item-renderer',
+  'ytd-grid-item-renderer',
+  'ytlr-tile-renderer',
+  'ytd-tile-renderer',
+  '[role="listitem"]',
+  '[role="treeitem"]',
+  '[role="menuitem"]'
+].join(',');
+const SHORTS_RESPONSE_KEYS = [
+  'reelShelfRenderer',
+  'reelShelfViewModel',
+  'shortsShelfRenderer',
+  'shortsLockupViewModel'
+];
 
 function findAdTile(adRenderer) {
   const semanticTile = adRenderer.closest(AD_TILE_SELECTOR);
@@ -122,27 +155,167 @@ function syncAdblockStyles() {
   }
 }
 
-function hideShortsRenderer(node) {
-  if (!node || node.nodeType !== 1) return;
-  node.classList.add('ytaf-hidden-shorts');
+function findShortsContainer(node) {
+  if (node.getAttribute('data-browse-id') === 'FEshorts') return node;
+
+  const semanticContainer = node.closest(SHORTS_ITEM_CONTAINER_SELECTOR);
+  if (semanticContainer) return semanticContainer;
+
+  let container = node;
+  for (let depth = 0; depth < 8 && container.parentElement; depth += 1) {
+    container = container.parentElement;
+    if (container.children.length > 1) return container;
+  }
+
+  return node;
+}
+
+function isShortsLink(node) {
+  if (!node || node.nodeType !== 1) return false;
+
+  const href = node.getAttribute('href') || '';
+  const uri = node.getAttribute('data-uri') || '';
+  const dataHref = node.getAttribute('data-href') || '';
+  const browseId = node.getAttribute('data-browse-id') || '';
+  const sectionId = node.getAttribute('data-section-id') || '';
+  const navId = node.getAttribute('data-nav-id') || '';
+  const dataId = node.getAttribute('data-id') || '';
+  const label =
+    node.getAttribute('aria-label') || node.getAttribute('title') || '';
+  const isNavigationNode =
+    node.tagName === 'A' ||
+    node.hasAttribute('data-uri') ||
+    node.hasAttribute('data-href') ||
+    node.hasAttribute('data-browse-id') ||
+    node.hasAttribute('data-section-id') ||
+    node.hasAttribute('data-nav-id') ||
+    node.hasAttribute('data-id');
+  return (
+    isNavigationNode &&
+    (label.toLowerCase() === 'shorts' ||
+      browseId === 'FEshorts' ||
+      sectionId.toLowerCase() === 'shorts' ||
+      navId.toLowerCase() === 'shorts' ||
+      dataId.toLowerCase() === 'shorts' ||
+      [href, uri, dataHref].some(isShortsPath))
+  );
+}
+
+function isShortsPath(value) {
+  if (!value) return false;
+
+  const path = value.split(/[?#]/, 1)[0];
+  return (
+    path === '/shorts' ||
+    path.startsWith('/shorts/') ||
+    path === '/feed/shorts' ||
+    path.startsWith('/feed/shorts/') ||
+    path === 'https://www.youtube.com/shorts' ||
+    path.startsWith('https://www.youtube.com/shorts/') ||
+    path === 'https://www.youtube.com/feed/shorts' ||
+    path.startsWith('https://www.youtube.com/feed/shorts/')
+  );
+}
+
+function getShortsLinkNode(value) {
+  if (!value || typeof value !== 'object') return null;
+
+  const endpoints = [
+    value.navigationEndpoint,
+    value.onSelectCommand,
+    value.command,
+    value.tileRenderer?.onSelectCommand,
+    value.richItemRenderer?.content?.shortsLockupViewModel?.onTap
+  ];
+  return endpoints.find((endpoint) => {
+    const path = endpoint?.commandMetadata?.webCommandMetadata?.url;
+    const browseId = endpoint?.browseEndpoint?.browseId;
+    return isShortsPath(path) || browseId === 'FEshorts';
+  });
+}
+
+function isShortsResponseEntry(value) {
+  if (!value || typeof value !== 'object') return false;
+
+  const content =
+    value.richItemRenderer?.content ||
+    value.tileRenderer?.content ||
+    value.content;
+  return Boolean(
+    SHORTS_RESPONSE_KEYS.some((key) =>
+      Object.prototype.hasOwnProperty.call(value, key)
+    ) ||
+    content?.shortsLockupViewModel ||
+    content?.reelItemRenderer ||
+    getShortsLinkNode(value)
+  );
+}
+
+function stripShortsFromBrowseResponse(value, depth = 0) {
+  if (!value || typeof value !== 'object' || depth > 32) return false;
+
+  let changed = false;
+  if (Array.isArray(value)) {
+    for (let index = value.length - 1; index >= 0; index -= 1) {
+      if (isShortsResponseEntry(value[index])) {
+        value.splice(index, 1);
+        changed = true;
+      } else {
+        changed =
+          stripShortsFromBrowseResponse(value[index], depth + 1) || changed;
+      }
+    }
+    return changed;
+  }
+
+  Object.keys(value).forEach((key) => {
+    if (SHORTS_RESPONSE_KEYS.includes(key)) {
+      delete value[key];
+      changed = true;
+      return;
+    }
+
+    changed = stripShortsFromBrowseResponse(value[key], depth + 1) || changed;
+  });
+
+  return changed;
+}
+
+function isBrowseResponse(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+
+  return (
+    !value.videoDetails &&
+    !value.streamingData &&
+    (value.contents ||
+      value.onResponseReceivedActions ||
+      value.onResponseReceivedEndpoints)
+  );
 }
 
 function syncShortsNode(node) {
   if (!node || node.nodeType !== 1) return;
 
-  if (node.matches(SHORTS_RENDERER_SELECTOR)) {
-    hideShortsRenderer(node);
-  } else {
-    node.classList.remove('ytaf-hidden-shorts');
-  }
+  const isRenderer = node.matches(SHORTS_RENDERER_SELECTOR);
+  const isLink = isShortsLink(node);
+  const isNavigationNode =
+    node.tagName === 'A' ||
+    node.hasAttribute('data-uri') ||
+    node.hasAttribute('data-href') ||
+    node.hasAttribute('data-browse-id');
+  const target =
+    isRenderer || !isNavigationNode ? node : findShortsContainer(node);
+
+  target.classList.toggle('ytaf-hidden-shorts', isRenderer || isLink);
 }
 
 function processShortsNode(node) {
   if (!node || node.nodeType !== 1) return;
 
   syncShortsNode(node);
-  node.querySelectorAll('.ytaf-hidden-shorts').forEach(syncShortsNode);
-  node.querySelectorAll(SHORTS_RENDERER_SELECTOR).forEach(hideShortsRenderer);
+  node
+    .querySelectorAll(`${SHORTS_RENDERER_SELECTOR}, ${SHORTS_LINK_SELECTOR}`)
+    .forEach(syncShortsNode);
 }
 
 function startShortsObserver() {
@@ -160,7 +333,18 @@ function startShortsObserver() {
   });
   shortsObserver.observe(document.body, {
     attributes: true,
-    attributeFilter: ['data-renderer-type'],
+    attributeFilter: [
+      'data-renderer-type',
+      'data-browse-id',
+      'data-section-id',
+      'data-nav-id',
+      'data-id',
+      'aria-label',
+      'title',
+      'href',
+      'data-uri',
+      'data-href'
+    ],
     childList: true,
     subtree: true
   });
@@ -326,6 +510,14 @@ JSON.parse = function () {
     if (stripAdditionalYouTubeAds(r)) {
       console.log('Adblock Removed additional renderers !');
     }
+  }
+
+  if (
+    !configRead('enableShorts') &&
+    isBrowseResponse(r) &&
+    stripShortsFromBrowseResponse(r)
+  ) {
+    console.log('Shorts disabled: removed browse renderers !');
   }
 
   return r;

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -240,7 +240,10 @@ function isShortsLink(node) {
   const hasShortsLabel = labels.some(
     (value) => value.toLowerCase() === 'shorts'
   );
-  const hasNavigationDestination = [href, uri, dataHref].some(Boolean);
+  const hasNavigationDestination = [href, uri, dataHref].some(
+    (value) =>
+      value && value !== '#' && value !== '#/' && !/^javascript:/i.test(value)
+  );
   const isLabelOnlyShorts =
     hasShortsLabel && isGuideNavigation && !hasNavigationDestination;
   return (

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -197,8 +197,12 @@ function isShortsLink(node) {
   const dataId = node.getAttribute('data-id') || '';
   const label =
     node.getAttribute('aria-label') || node.getAttribute('title') || '';
+  const role = node.getAttribute('role') || '';
   const isNavigationNode =
     node.tagName === 'A' ||
+    role === 'link' ||
+    role === 'menuitem' ||
+    role === 'treeitem' ||
     node.hasAttribute('data-uri') ||
     node.hasAttribute('data-href') ||
     node.hasAttribute('data-browse-id') ||

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -59,6 +59,8 @@ const SHORTS_LINK_SELECTOR = [
   '[role="treeitem"][title="Shorts"]'
 ].join(',');
 const SHORTS_LABEL_SELECTOR = '[aria-label], [title]';
+const SHORTS_MARKER_SELECTOR =
+  '[data-browse-id], [data-section-id], [data-nav-id], [data-id]';
 const SHORTS_ITEM_CONTAINER_SELECTOR = [
   'ytlr-guide-entry-renderer',
   'ytd-guide-entry-renderer',
@@ -215,12 +217,24 @@ function isShortsLink(node) {
     node.hasAttribute('data-id');
   return (
     isNavigationNode &&
-    (label.toLowerCase() === 'shorts' ||
+    ((label.toLowerCase() === 'shorts' && !isWatchPath(href)) ||
       browseId === 'FEshorts' ||
       sectionId.toLowerCase() === 'shorts' ||
       navId.toLowerCase() === 'shorts' ||
       dataId.toLowerCase() === 'shorts' ||
       [href, uri, dataHref].some(isShortsPath))
+  );
+}
+
+function isWatchPath(value) {
+  if (!value) return false;
+
+  const path = value.split(/[?#]/, 1)[0];
+  return (
+    path === '/watch' ||
+    path.startsWith('/watch/') ||
+    path === 'https://www.youtube.com/watch' ||
+    path.startsWith('https://www.youtube.com/watch/')
   );
 }
 
@@ -258,7 +272,7 @@ function processShortsNode(node) {
   syncShortsNode(node);
   node
     .querySelectorAll(
-      `${SHORTS_RENDERER_SELECTOR}, ${SHORTS_LINK_SELECTOR}, ${SHORTS_LABEL_SELECTOR}`
+      `${SHORTS_RENDERER_SELECTOR}, ${SHORTS_LINK_SELECTOR}, ${SHORTS_LABEL_SELECTOR}, ${SHORTS_MARKER_SELECTOR}`
     )
     .forEach(syncShortsNode);
 }

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -246,6 +246,7 @@ function startShortsObserver() {
       if (mutation.type === 'attributes') {
         syncShortsNode(mutation.target);
       } else {
+        processShortsNode(mutation.target);
         mutation.addedNodes.forEach(processShortsNode);
       }
     });

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -79,6 +79,19 @@ const SHORTS_ITEM_CONTAINER_SELECTOR = [
   '[role="treeitem"]',
   '[role="menuitem"]'
 ].join(',');
+const SHORTS_ITEM_RESCAN_SELECTOR = [
+  'ytlr-guide-entry-renderer',
+  'ytd-guide-entry-renderer',
+  'ytlr-rich-item-renderer',
+  'ytd-rich-item-renderer',
+  'ytlr-grid-item-renderer',
+  'ytd-grid-item-renderer',
+  'ytlr-tile-renderer',
+  'ytd-tile-renderer',
+  '[role="listitem"]',
+  '[role="treeitem"]',
+  '[role="menuitem"]'
+].join(',');
 function findAdTile(adRenderer) {
   const semanticTile = adRenderer.closest(AD_TILE_SELECTOR);
   if (semanticTile) return semanticTile;
@@ -188,9 +201,10 @@ function collectShortsAncestors(node, targets) {
   while (ancestor) {
     if (
       ancestor.classList.contains('ytaf-hidden-shorts') ||
-      ancestor.matches(SHORTS_ITEM_CONTAINER_SELECTOR)
+      ancestor.matches(SHORTS_ITEM_RESCAN_SELECTOR)
     ) {
       targets.add(ancestor);
+      return;
     }
     ancestor = ancestor.parentElement;
   }

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -222,7 +222,8 @@ function isShortsLink(node) {
     node.hasAttribute('data-id');
   return (
     isNavigationNode &&
-    ((label.toLowerCase() === 'shorts' && !isWatchPath(href)) ||
+    ((label.toLowerCase() === 'shorts' &&
+      ![href, uri, dataHref].some(isWatchPath)) ||
       browseId === 'FEshorts' ||
       sectionId.toLowerCase() === 'shorts' ||
       navId.toLowerCase() === 'shorts' ||
@@ -313,12 +314,18 @@ function startShortsObserver() {
   processShortsNode(document.body);
   shortsObserver = new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
+      const target =
+        mutation.type === 'characterData'
+          ? mutation.target.parentElement
+          : mutation.target;
+      if (!target) return;
+
       if (mutation.type === 'attributes') {
-        syncShortsNode(mutation.target);
-        syncShortsAncestor(mutation.target);
+        syncShortsNode(target);
+        syncShortsAncestor(target);
       } else {
-        processShortsNode(mutation.target);
-        syncShortsAncestor(mutation.target);
+        processShortsNode(target);
+        syncShortsAncestor(target);
         mutation.addedNodes.forEach(processShortsNode);
       }
     });

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -58,6 +58,7 @@ const SHORTS_LINK_SELECTOR = [
   '[role="treeitem"][aria-label="Shorts"]',
   '[role="treeitem"][title="Shorts"]'
 ].join(',');
+const SHORTS_LABEL_SELECTOR = '[aria-label], [title]';
 const SHORTS_ITEM_CONTAINER_SELECTOR = [
   'ytlr-guide-entry-renderer',
   'ytd-guide-entry-renderer',
@@ -177,7 +178,7 @@ function syncShortsAncestor(node) {
   if (!node || node.nodeType !== 1) return;
 
   let ancestor = node.parentElement;
-  for (let depth = 0; ancestor && depth < 8; depth += 1) {
+  while (ancestor) {
     if (
       ancestor.classList.contains('ytaf-hidden-shorts') ||
       ancestor.matches(SHORTS_ITEM_CONTAINER_SELECTOR)
@@ -256,7 +257,9 @@ function processShortsNode(node) {
   node.querySelectorAll('.ytaf-hidden-shorts').forEach(syncShortsNode);
   syncShortsNode(node);
   node
-    .querySelectorAll(`${SHORTS_RENDERER_SELECTOR}, ${SHORTS_LINK_SELECTOR}`)
+    .querySelectorAll(
+      `${SHORTS_RENDERER_SELECTOR}, ${SHORTS_LINK_SELECTOR}, ${SHORTS_LABEL_SELECTOR}`
+    )
     .forEach(syncShortsNode);
 }
 

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -244,8 +244,13 @@ function isShortsLink(node) {
     (value) =>
       value && value !== '#' && value !== '#/' && !/^javascript:/i.test(value)
   );
+  const hasOrdinaryBrowseDestination =
+    browseId && browseId.toLowerCase() !== 'feshorts';
   const isLabelOnlyShorts =
-    hasShortsLabel && isGuideNavigation && !hasNavigationDestination;
+    hasShortsLabel &&
+    isGuideNavigation &&
+    !hasNavigationDestination &&
+    !hasOrdinaryBrowseDestination;
   return (
     isNavigationNode &&
     (isLabelOnlyShorts ||

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -197,6 +197,7 @@ function collectShortsAncestors(node, targets) {
   while (ancestor) {
     if (
       ancestor.classList.contains('ytaf-hidden-shorts') ||
+      ancestor.matches(SHORTS_SHELF_HEADER_SELECTOR) ||
       ancestor.matches(SHORTS_ITEM_RESCAN_SELECTOR)
     ) {
       targets.add(ancestor);

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -216,8 +216,10 @@ function isShortsLink(node) {
   const sectionId = node.getAttribute('data-section-id') || '';
   const navId = node.getAttribute('data-nav-id') || '';
   const dataId = node.getAttribute('data-id') || '';
-  const label =
-    node.getAttribute('aria-label') || node.getAttribute('title') || '';
+  const labels = [
+    node.getAttribute('aria-label') || '',
+    node.getAttribute('title') || ''
+  ];
   const role = node.getAttribute('role') || '';
   const isNavigationNode =
     node.tagName === 'A' ||
@@ -235,11 +237,15 @@ function isShortsLink(node) {
       'ytlr-guide-entry-renderer, ytd-guide-entry-renderer, [role="tree"], [role="menu"], [role="menubar"], [role="navigation"]'
     )
   );
+  const hasShortsLabel = labels.some(
+    (value) => value.toLowerCase() === 'shorts'
+  );
+  const hasNavigationDestination = [href, uri, dataHref].some(Boolean);
+  const isLabelOnlyShorts =
+    hasShortsLabel && isGuideNavigation && !hasNavigationDestination;
   return (
     isNavigationNode &&
-    ((label.toLowerCase() === 'shorts' &&
-      isGuideNavigation &&
-      ![href, uri, dataHref].some(isWatchPath)) ||
+    (isLabelOnlyShorts ||
       browseId === 'FEshorts' ||
       sectionId.toLowerCase() === 'shorts' ||
       navId.toLowerCase() === 'shorts' ||
@@ -263,18 +269,6 @@ function findShortsShelfContainer(node) {
     'ytlr-shelf-renderer, ytd-shelf-renderer, ytlr-section-list-renderer, ytd-section-list-renderer'
   );
   return shelfContainer || node;
-}
-
-function isWatchPath(value) {
-  if (!value) return false;
-
-  const path = value.split(/[?#]/, 1)[0];
-  return (
-    path === '/watch' ||
-    path.startsWith('/watch/') ||
-    path === 'https://www.youtube.com/watch' ||
-    path.startsWith('https://www.youtube.com/watch/')
-  );
 }
 
 function isShortsPath(value) {


### PR DESCRIPTION
Integrates #52 on top of the current main after #49/#50/#51.

Changes:
- preserve the sponsored QR popup blocker and existing adblock behavior
- apply #52's broader Shorts sidebar/shelf/navigation detection
- keep direct Shorts playback available
- retain the current CI workflow including `npm test`

GitHub performed the three-way merge from current main and the original #52 head; this PR validates that integrated result before it reaches main.