### PR TITLE
Fix Shorts blocking on TV builds

### DIFF
--- a/webapp/src/adblock-main.js
+++ b/webapp/src/adblock-main.js
@@ -11,6 +11,7 @@ import { configRead } from './config.js';
 import { userScriptStartUI } from './ui.js';
 import { userScriptStartSponsoredQrCodeUI } from './sponsored-qr-code-ui.js';
 import { userScriptStartAdBlock, userScriptStartShorts } from './adblock.js';
+import { userScriptStartShortsBlockUI } from './shorts-block.js';
 import { userScriptStartSponsorBlock } from './sponsorblock.js';
 import { userScriptStartReturnYouTubeDislike } from './returnyoutubedislike.js';
 import { resetAutoLogin } from './auto-login.js';
@@ -105,6 +106,7 @@ export async function startUserScript() {
 
   try {
     userScriptStartUI();
+    userScriptStartShortsBlockUI();
     userScriptStartSponsoredQrCodeUI();
     userScriptStartShorts();
     startDebugOverlay();

--- a/webapp/src/checkboxTools.js
+++ b/webapp/src/checkboxTools.js
@@ -131,6 +131,20 @@ function uncheck(name) {
   callbacks[sliceDiv.tabIndex]?.(false);
 }
 
+function setCallback(name, callback) {
+  if (!name) return false;
+
+  const sliceDiv = document.querySelector('#' + name);
+  if (!sliceDiv || sliceDiv.tabIndex <= 0) return false;
+
+  callbacks[sliceDiv.tabIndex] = (newState) => {
+    if (callback != null) {
+      callback(newState);
+    }
+  };
+  return true;
+}
+
 function remove(name) {
   if (!name) {
     return;
@@ -145,5 +159,6 @@ export const checkboxTools = {
   toggleCheck: toggleCheck,
   check: check,
   uncheck: uncheck,
+  setCallback: setCallback,
   remove: remove
 };

--- a/webapp/src/shorts-block.js
+++ b/webapp/src/shorts-block.js
@@ -1,0 +1,82 @@
+import { checkboxTools } from './checkboxTools.js';
+import { configRead, configWrite } from './config.js';
+import { getLanguage } from './languages/index.js';
+import {
+  isBrowseResponse,
+  stripShortsFromBrowseResponse
+} from './shorts-response-filter.mjs';
+
+const SHORTS_BLOCK_LABELS = {
+  de: 'YouTube Shorts blockieren',
+  en: 'Block YouTube Shorts',
+  es: 'Bloquear YouTube Shorts',
+  fr: 'Bloquer YouTube Shorts',
+  it: 'Blocca YouTube Shorts',
+  nl: 'YouTube Shorts blokkeren',
+  pl: 'Blokuj YouTube Shorts',
+  pt: 'Bloquear YouTube Shorts'
+};
+
+function getLabel() {
+  const language = getLanguage();
+  return SHORTS_BLOCK_LABELS[language] || SHORTS_BLOCK_LABELS.en;
+}
+
+function reloadForShortsChange() {
+  window.setTimeout(() => {
+    try {
+      if (window.location && typeof window.location.reload === 'function') {
+        window.location.reload();
+      } else if (window.location) {
+        window.location.href = window.location.href;
+      }
+    } catch (err) {
+      console.warn('[ytaf] Failed to reload after Shorts setting change:', err);
+    }
+  }, 100);
+}
+
+function installResponseFilter() {
+  if (window.__ytafShortsResponseFilterInstalled) return;
+  window.__ytafShortsResponseFilterInstalled = true;
+
+  const previousParse = JSON.parse;
+  JSON.parse = function () {
+    const value = previousParse.apply(this, arguments);
+
+    if (
+      !configRead('enableShorts') &&
+      isBrowseResponse(value) &&
+      stripShortsFromBrowseResponse(value)
+    ) {
+      console.log('Shorts blocker removed browse renderers !');
+    }
+
+    return value;
+  };
+}
+
+export function userScriptStartShortsBlockUI() {
+  const control = document.querySelector('#__shorts');
+  if (!control) return;
+
+  const wrapper = control.parentElement;
+  const description = wrapper && wrapper.querySelector('.desc');
+  if (description) {
+    description.textContent = getLabel();
+  }
+
+  const blocked = !Boolean(configRead('enableShorts'));
+  if (blocked) {
+    control.setAttribute('checked', 'checked');
+  } else {
+    control.removeAttribute('checked');
+  }
+
+  checkboxTools.setCallback('__shorts', (newState) => {
+    configWrite('enableShorts', !newState);
+    reloadForShortsChange();
+  });
+}
+
+installResponseFilter();

--- a/webapp/src/shorts-response-filter.mjs
+++ b/webapp/src/shorts-response-filter.mjs
@@ -1,0 +1,100 @@
+const SHORTS_RESPONSE_KEYS = [
+  'reelShelfRenderer',
+  'reelShelfViewModel',
+  'shortsShelfRenderer',
+  'shortsLockupViewModel'
+];
+
+export function isShortsPath(value) {
+  if (!value) return false;
+
+  const path = value.split(/[?#]/, 1)[0];
+  return (
+    path === '/shorts' ||
+    path.startsWith('/shorts/') ||
+    path === '/feed/shorts' ||
+    path.startsWith('/feed/shorts/') ||
+    path === 'https://www.youtube.com/shorts' ||
+    path.startsWith('https://www.youtube.com/shorts/') ||
+    path === 'https://www.youtube.com/feed/shorts' ||
+    path.startsWith('https://www.youtube.com/feed/shorts/')
+  );
+}
+
+function getShortsLinkNode(value) {
+  if (!value || typeof value !== 'object') return null;
+
+  const endpoints = [
+    value.navigationEndpoint,
+    value.onSelectCommand,
+    value.command,
+    value.tileRenderer?.onSelectCommand,
+    value.richItemRenderer?.content?.shortsLockupViewModel?.onTap
+  ];
+
+  return endpoints.find((endpoint) => {
+    const path = endpoint?.commandMetadata?.webCommandMetadata?.url;
+    const browseId = endpoint?.browseEndpoint?.browseId;
+    return isShortsPath(path) || browseId === 'FEshorts';
+  });
+}
+
+export function isShortsResponseEntry(value) {
+  if (!value || typeof value !== 'object') return false;
+
+  const content =
+    value.richItemRenderer?.content ||
+    value.tileRenderer?.content ||
+    value.content;
+
+  return Boolean(
+    SHORTS_RESPONSE_KEYS.some((key) =>
+      Object.prototype.hasOwnProperty.call(value, key)
+    ) ||
+      content?.shortsLockupViewModel ||
+      content?.reelItemRenderer ||
+      getShortsLinkNode(value)
+  );
+}
+
+export function stripShortsFromBrowseResponse(value, depth = 0) {
+  if (!value || typeof value !== 'object' || depth > 32) return false;
+
+  let changed = false;
+  if (Array.isArray(value)) {
+    for (let index = value.length - 1; index >= 0; index -= 1) {
+      if (isShortsResponseEntry(value[index])) {
+        value.splice(index, 1);
+        changed = true;
+      } else {
+        changed =
+          stripShortsFromBrowseResponse(value[index], depth + 1) || changed;
+      }
+    }
+    return changed;
+  }
+
+  Object.keys(value).forEach((key) => {
+    if (SHORTS_RESPONSE_KEYS.includes(key)) {
+      delete value[key];
+      changed = true;
+      return;
+    }
+
+    changed = stripShortsFromBrowseResponse(value[key], depth + 1) || changed;
+  });
+
+  return changed;
+}
+
+export function isBrowseResponse(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+
+  return Boolean(
+    !value.videoDetails &&
+      !value.streamingData &&
+      (value.contents ||
+        value.onResponseReceivedActions ||
+        value.onResponseReceivedEndpoints)
+  );
+}

--- a/webapp/test/shorts-response-filter.test.mjs
+++ b/webapp/test/shorts-response-filter.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  isBrowseResponse,
+  isShortsPath,
+  stripShortsFromBrowseResponse
+} from '../src/shorts-response-filter.mjs';
+
+test('recognizes Shorts navigation paths', () => {
+  assert.equal(isShortsPath('/shorts/abc'), true);
+  assert.equal(isShortsPath('/feed/shorts?bp=123'), true);
+  assert.equal(isShortsPath('/watch?v=abc'), false);
+});
+
+test('removes Shorts entries from browse responses only', () => {
+  const response = {
+    contents: {
+      items: [
+        { videoRenderer: { videoId: 'normal' } },
+        { shortsLockupViewModel: { entityId: 'short' } },
+        {
+          navigationEndpoint: {
+            commandMetadata: {
+              webCommandMetadata: { url: '/shorts/abc' }
+            }
+          }
+        }
+      ]
+    }
+  };
+
+  assert.equal(isBrowseResponse(response), true);
+  assert.equal(stripShortsFromBrowseResponse(response), true);
+  assert.deepEqual(response.contents.items, [
+    { videoRenderer: { videoId: 'normal' } }
+  ]);
+});
+
+test('does not classify direct player responses as browse responses', () => {
+  const playerResponse = {
+    videoDetails: { videoId: 'short-video' },
+    streamingData: { formats: [] },
+    contents: { shortsLockupViewModel: {} }
+  };
+
+  assert.equal(isBrowseResponse(playerResponse), false);
+});
+
+test('removes FEshorts navigation entries but keeps ordinary browse entries', () => {
+  const response = {
+    onResponseReceivedActions: [
+      {
+        navigationEndpoint: {
+          browseEndpoint: { browseId: 'FEshorts' }
+        }
+      },
+      {
+        navigationEndpoint: {
+          browseEndpoint: { browseId: 'FEsubscriptions' }
+        }
+      }
+    ]
+  };
+
+  assert.equal(stripShortsFromBrowseResponse(response), true);
+  assert.deepEqual(response.onResponseReceivedActions, [
+    {
+      navigationEndpoint: {
+        browseEndpoint: { browseId: 'FEsubscriptions' }
+      }
+    }
+  ]);
+});


### PR DESCRIPTION
Fixes the Shorts blocker after #52 for TV builds where the DOM selectors still do not match.

Changes:
- make the visible option consistently mean "Block YouTube Shorts"
- keep the existing `enableShorts` storage key for backward compatibility
- add browse-response filtering before rendering as the primary blocker
- keep the existing DOM observer as a fallback
- reload after toggling so enabling/disabling is fully reversible
- add tests for Shorts browse filtering and direct player-response preservation