### PR TITLE
Clean up Shorts blocker translations

### DIFF
--- a/webapp/src/languages/de.js
+++ b/webapp/src/languages/de.js
@@ -10,7 +10,7 @@ export default {
     autoLogin: 'Kontoauswahl automatisch überspringen',
     sponsorblock: 'SponsorBlock aktivieren',
     ryd: 'Dislike-Zahlen anzeigen',
-    shorts: 'YouTube Shorts aktivieren',
+    shorts: 'YouTube Shorts blockieren',
     sponsor: 'Sponsor-Segmente überspringen',
     intro: 'Intro überspringen',
     outro: 'Outro überspringen',

--- a/webapp/src/languages/en.js
+++ b/webapp/src/languages/en.js
@@ -10,7 +10,7 @@ export default {
     autoLogin: 'Automatically skip account selection',
     sponsorblock: 'Enable SponsorBlock',
     ryd: 'Show dislike counts',
-    shorts: 'Enable YouTube Shorts',
+    shorts: 'Block YouTube Shorts',
     sponsor: 'Skip Sponsor Segments',
     intro: 'Skip Intro Segments',
     outro: 'Skip Outro Segments',

--- a/webapp/src/languages/es.js
+++ b/webapp/src/languages/es.js
@@ -1,7 +1,7 @@
 export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
-    adblock: 'Bloquear anuncios', startupPage: 'Página de inicio', startupPageHome: 'Inicio', startupPageSubscriptions: 'Suscripciones', startupPageShorts: 'Shorts', startupPageLibrary: 'Biblioteca', autoLogin: 'Omitir automáticamente la selección de cuenta', sponsorblock: 'Activar SponsorBlock', ryd: 'Mostrar recuento de no me gusta', shorts: 'Activar YouTube Shorts',
+    adblock: 'Bloquear anuncios', startupPage: 'Página de inicio', startupPageHome: 'Inicio', startupPageSubscriptions: 'Suscripciones', startupPageShorts: 'Shorts', startupPageLibrary: 'Biblioteca', autoLogin: 'Omitir automáticamente la selección de cuenta', sponsorblock: 'Activar SponsorBlock', ryd: 'Mostrar recuento de no me gusta', shorts: 'Bloquear YouTube Shorts',
     sponsor: 'Saltar segmentos patrocinados', intro: 'Saltar introducciones', outro: 'Saltar finales',
     interaction: 'Saltar recordatorios de suscripción y me gusta', selfpromo: 'Saltar autopromoción',
     musicOfftopic: 'Saltar música/fuera de tema', preview: 'Saltar avances/resúmenes',

--- a/webapp/src/languages/fr.js
+++ b/webapp/src/languages/fr.js
@@ -1,7 +1,7 @@
 export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
-    adblock: 'Bloquer les publicités', startupPage: 'Page de démarrage', startupPageHome: 'Accueil', startupPageSubscriptions: 'Abonnements', startupPageShorts: 'Shorts', startupPageLibrary: 'Bibliothèque', autoLogin: 'Ignorer automatiquement le choix du compte', sponsorblock: 'Activer SponsorBlock', ryd: 'Afficher le nombre de dislikes', shorts: 'Activer YouTube Shorts',
+    adblock: 'Bloquer les publicités', startupPage: 'Page de démarrage', startupPageHome: 'Accueil', startupPageSubscriptions: 'Abonnements', startupPageShorts: 'Shorts', startupPageLibrary: 'Bibliothèque', autoLogin: 'Ignorer automatiquement le choix du compte', sponsorblock: 'Activer SponsorBlock', ryd: 'Afficher le nombre de dislikes', shorts: 'Bloquer YouTube Shorts',
     sponsor: 'Ignorer les segments sponsorisés', intro: 'Ignorer les introductions', outro: 'Ignorer les conclusions',
     interaction: 'Ignorer les rappels d’abonnement et de mention J’aime', selfpromo: 'Ignorer l’autopromotion',
     musicOfftopic: 'Ignorer la musique/hors sujet', preview: 'Ignorer les aperçus/récapitulatifs',

--- a/webapp/src/languages/it.js
+++ b/webapp/src/languages/it.js
@@ -10,7 +10,7 @@ export default {
     autoLogin: 'Salta automaticamente la selezione account',
     sponsorblock: 'Attiva SponsorBlock',
     ryd: 'Mostra numero di non mi piace',
-    shorts: 'Attiva YouTube Shorts',
+    shorts: 'Blocca YouTube Shorts',
     sponsor: 'Salta segmenti sponsor',
     intro: 'Salta intro',
     outro: 'Salta outro',

--- a/webapp/src/languages/nl.js
+++ b/webapp/src/languages/nl.js
@@ -1,7 +1,7 @@
 export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
-    adblock: 'Advertenties blokkeren', startupPage: 'Startpagina', startupPageHome: 'Home', startupPageSubscriptions: 'Abonnementen', startupPageShorts: 'Shorts', startupPageLibrary: 'Bibliotheek', autoLogin: 'Accountselectie automatisch overslaan', sponsorblock: 'SponsorBlock inschakelen', ryd: 'Aantal dislikes tonen', shorts: 'YouTube Shorts inschakelen',
+    adblock: 'Advertenties blokkeren', startupPage: 'Startpagina', startupPageHome: 'Home', startupPageSubscriptions: 'Abonnementen', startupPageShorts: 'Shorts', startupPageLibrary: 'Bibliotheek', autoLogin: 'Accountselectie automatisch overslaan', sponsorblock: 'SponsorBlock inschakelen', ryd: 'Aantal dislikes tonen', shorts: 'YouTube Shorts blokkeren',
     sponsor: 'Sponsorsegmenten overslaan', intro: 'Introsegmenten overslaan', outro: 'Outrosegmenten overslaan',
     interaction: 'Abonnements- en likeherinneringen overslaan', selfpromo: 'Zelfpromotie overslaan',
     musicOfftopic: 'Muziek/off-topic overslaan', preview: 'Vooruitblik/samenvatting overslaan',

--- a/webapp/src/languages/pl.js
+++ b/webapp/src/languages/pl.js
@@ -1,7 +1,7 @@
 export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
-    adblock: 'Blokuj reklamy', startupPage: 'Strona startowa', startupPageHome: 'Główna', startupPageSubscriptions: 'Subskrypcje', startupPageShorts: 'Shorts', startupPageLibrary: 'Biblioteka', autoLogin: 'Automatycznie pomijaj wybór konta', sponsorblock: 'Włącz SponsorBlock', ryd: 'Pokaż liczbę negatywnych ocen', shorts: 'Włącz YouTube Shorts',
+    adblock: 'Blokuj reklamy', startupPage: 'Strona startowa', startupPageHome: 'Główna', startupPageSubscriptions: 'Subskrypcje', startupPageShorts: 'Shorts', startupPageLibrary: 'Biblioteka', autoLogin: 'Automatycznie pomijaj wybór konta', sponsorblock: 'Włącz SponsorBlock', ryd: 'Pokaż liczbę negatywnych ocen', shorts: 'Blokuj YouTube Shorts',
     sponsor: 'Pomiń segmenty sponsorskie', intro: 'Pomiń intro', outro: 'Pomiń zakończenie',
     interaction: 'Pomiń przypomnienia o subskrypcji i polubieniu', selfpromo: 'Pomiń autopromocję',
     musicOfftopic: 'Pomiń muzykę/treści nie na temat', preview: 'Pomiń zapowiedź/podsumowanie',

--- a/webapp/src/languages/pt.js
+++ b/webapp/src/languages/pt.js
@@ -1,7 +1,7 @@
 export default {
   ui: {
     title: 'YouTube webOS Cobalt AdFree',
-    adblock: 'Bloquear anúncios', startupPage: 'Página inicial', startupPageHome: 'Início', startupPageSubscriptions: 'Inscrições', startupPageShorts: 'Shorts', startupPageLibrary: 'Biblioteca', autoLogin: 'Ignorar automaticamente a seleção de conta', sponsorblock: 'Ativar SponsorBlock', ryd: 'Mostrar contagem de não gostei', shorts: 'Ativar YouTube Shorts',
+    adblock: 'Bloquear anúncios', startupPage: 'Página inicial', startupPageHome: 'Início', startupPageSubscriptions: 'Inscrições', startupPageShorts: 'Shorts', startupPageLibrary: 'Biblioteca', autoLogin: 'Ignorar automaticamente a seleção de conta', sponsorblock: 'Ativar SponsorBlock', ryd: 'Mostrar contagem de não gostei', shorts: 'Bloquear YouTube Shorts',
     sponsor: 'Pular segmentos patrocinados', intro: 'Pular introduções', outro: 'Pular encerramentos',
     interaction: 'Pular lembretes de inscrição e curtir', selfpromo: 'Pular autopromoção',
     musicOfftopic: 'Pular música/fora do assunto', preview: 'Pular prévias/resumos',

--- a/webapp/src/shorts-block.js
+++ b/webapp/src/shorts-block.js
@@ -1,26 +1,10 @@
 import { checkboxTools } from './checkboxTools.js';
 import { configRead, configWrite } from './config.js';
-import { getLanguage } from './languages/index.js';
+import { text as languageText } from './languages/index.js';
 import {
   isBrowseResponse,
   stripShortsFromBrowseResponse
 } from './shorts-response-filter.mjs';
-
-const SHORTS_BLOCK_LABELS = {
-  de: 'YouTube Shorts blockieren',
-  en: 'Block YouTube Shorts',
-  es: 'Bloquear YouTube Shorts',
-  fr: 'Bloquer YouTube Shorts',
-  it: 'Blocca YouTube Shorts',
-  nl: 'YouTube Shorts blokkeren',
-  pl: 'Blokuj YouTube Shorts',
-  pt: 'Bloquear YouTube Shorts'
-};
-
-function getLabel() {
-  const language = getLanguage();
-  return SHORTS_BLOCK_LABELS[language] || SHORTS_BLOCK_LABELS.en;
-}
 
 function reloadForShortsChange() {
   window.setTimeout(() => {
@@ -63,7 +47,7 @@ export function userScriptStartShortsBlockUI() {
   const wrapper = control.parentElement;
   const description = wrapper && wrapper.querySelector('.desc');
   if (description) {
-    description.textContent = getLabel();
+    description.textContent = languageText('ui', 'shorts');
   }
 
   const blocked = !Boolean(configRead('enableShorts'));


### PR DESCRIPTION
Moves the Shorts blocker label back into the shared language files and removes the embedded translation table from `shorts-block.js`.

Changes:
- use the existing language service for the Shorts label
- update all 8 supported translations to the new blocking semantics
- keep the existing Shorts blocker behavior unchanged

This is a translation/structure cleanup only.