### PR TITLE
Filter YouTube TV Shorts shelves before rendering

### DIFF
--- a/webapp/src/adblock-main.js
+++ b/webapp/src/adblock-main.js
@@ -10,7 +10,7 @@ import { handleInitialLaunch, handleLaunch, waitForChildAdd } from './utils';
 import { configRead } from './config.js';
 import { userScriptStartUI } from './ui.js';
 import { userScriptStartSponsoredQrCodeUI } from './sponsored-qr-code-ui.js';
-import { userScriptStartAdBlock, userScriptStartShorts } from './adblock.js';
+import { userScriptStartAdBlock } from './adblock.js';
 import { userScriptStartShortsBlockUI } from './shorts-block.js';
 import { userScriptStartSponsorBlock } from './sponsorblock.js';
 import { userScriptStartReturnYouTubeDislike } from './returnyoutubedislike.js';
@@ -108,7 +108,6 @@ export async function startUserScript() {
     userScriptStartUI();
     userScriptStartShortsBlockUI();
     userScriptStartSponsoredQrCodeUI();
-    userScriptStartShorts();
     startDebugOverlay();
     console.info('[ytaf] UI started');
   } catch (err) {

--- a/webapp/src/adblock.css
+++ b/webapp/src/adblock.css
@@ -10,12 +10,6 @@ html.ytaf-adblock-enabled ytd-masthead-ad-v3-renderer {
   pointer-events: none !important;
 }
 
-html.ytaf-shorts-disabled .ytaf-hidden-shorts {
-  display: none !important;
-  visibility: hidden !important;
-  pointer-events: none !important;
-}
-
 html.ytaf-adblock-enabled .ytaf-hidden-ad-tile {
   display: none !important;
   visibility: hidden !important;

--- a/webapp/src/adblock.js
+++ b/webapp/src/adblock.js
@@ -20,13 +20,7 @@ const AD_TILE_SELECTOR = [
   '[role="gridcell"]'
 ].join(',');
 
-const SHORTS_GUIDE_ENTRY_SELECTOR =
-  'ytlr-guide-entry-renderer, ytd-guide-entry-renderer';
-const SHORTS_SHELF_SELECTOR = 'ytlr-shelf-renderer, ytd-shelf-renderer';
-const SHORTS_SHELF_HEADER_SELECTOR = 'ytlr-shelf-header, ytd-shelf-header';
-
 let adSlotObserver = null;
-let shortsObserver = null;
 
 function findAdTile(adRenderer) {
   const semanticTile = adRenderer.closest(AD_TILE_SELECTOR);
@@ -113,130 +107,8 @@ function syncAdblockStyles() {
   }
 }
 
-function isShortsLabel(value) {
-  return (value || '').trim().toLowerCase() === 'shorts';
-}
-
-function syncShortsGuideEntry(entry) {
-  if (!entry || entry.nodeType !== 1) return;
-
-  // On YouTube TV the guide entry itself lives in an absolutely positioned
-  // wrapper. Hide that wrapper so the complete sidebar item disappears.
-  const target = entry.parentElement || entry;
-  target.classList.toggle(
-    'ytaf-hidden-shorts',
-    isShortsLabel(entry.getAttribute('aria-label'))
-  );
-}
-
-function syncShortsShelf(shelf) {
-  if (!shelf || shelf.nodeType !== 1) return;
-
-  const header = shelf.querySelector(SHORTS_SHELF_HEADER_SELECTOR);
-  shelf.classList.toggle(
-    'ytaf-hidden-shorts',
-    Boolean(header && isShortsLabel(header.textContent))
-  );
-}
-
-function scanShortsRoot(root) {
-  if (!root) return;
-
-  if (root.nodeType === 1) {
-    if (root.matches(SHORTS_GUIDE_ENTRY_SELECTOR)) {
-      syncShortsGuideEntry(root);
-    }
-    if (root.matches(SHORTS_SHELF_SELECTOR)) {
-      syncShortsShelf(root);
-    }
-  }
-
-  if (typeof root.querySelectorAll !== 'function') return;
-
-  root
-    .querySelectorAll(SHORTS_GUIDE_ENTRY_SELECTOR)
-    .forEach(syncShortsGuideEntry);
-  root.querySelectorAll(SHORTS_SHELF_SELECTOR).forEach(syncShortsShelf);
-}
-
-function syncClosestShortsShelf(node) {
-  if (!node) return;
-
-  const element = node.nodeType === 1 ? node : node.parentElement;
-  if (!element || typeof element.closest !== 'function') return;
-
-  const shelf = element.matches(SHORTS_SHELF_SELECTOR)
-    ? element
-    : element.closest(SHORTS_SHELF_SELECTOR);
-  if (shelf) syncShortsShelf(shelf);
-}
-
-function processShortsMutation(mutation) {
-  if (mutation.type === 'attributes') {
-    if (mutation.target.matches(SHORTS_GUIDE_ENTRY_SELECTOR)) {
-      syncShortsGuideEntry(mutation.target);
-    }
-    syncClosestShortsShelf(mutation.target);
-    return;
-  }
-
-  syncClosestShortsShelf(mutation.target);
-
-  mutation.addedNodes.forEach((node) => {
-    if (node.nodeType === 1) {
-      scanShortsRoot(node);
-      syncClosestShortsShelf(node);
-    } else {
-      syncClosestShortsShelf(node);
-    }
-  });
-}
-
-function startShortsObserver() {
-  if (shortsObserver || !document.body) return;
-
-  scanShortsRoot(document.body);
-
-  shortsObserver = new MutationObserver((mutations) => {
-    mutations.forEach(processShortsMutation);
-  });
-  shortsObserver.observe(document.body, {
-    attributes: true,
-    attributeFilter: ['aria-label'],
-    childList: true,
-    characterData: true,
-    subtree: true
-  });
-}
-
-function stopShortsObserver() {
-  if (shortsObserver) {
-    shortsObserver.disconnect();
-    shortsObserver = null;
-  }
-
-  document.querySelectorAll('.ytaf-hidden-shorts').forEach((node) => {
-    node.classList.remove('ytaf-hidden-shorts');
-  });
-}
-
-function syncShortsVisibility() {
-  const enabled = Boolean(configRead('enableShorts'));
-  document.documentElement.classList.toggle('ytaf-shorts-disabled', !enabled);
-
-  if (enabled) {
-    stopShortsObserver();
-  } else {
-    startShortsObserver();
-  }
-}
-
 export function userScriptStartAdBlock() {
   syncAdblockStyles();
-}
-
-export function userScriptStartShorts() {
-  syncShortsVisibility();
 }
 
 document.addEventListener(
@@ -244,9 +116,6 @@ document.addEventListener(
   (event) => {
     if (event.detail && event.detail.key === 'enableAdBlock') {
       syncAdblockStyles();
-    }
-    if (event.detail && event.detail.key === 'enableShorts') {
-      syncShortsVisibility();
     }
   },
   true

--- a/webapp/src/shorts-response-filter.mjs
+++ b/webapp/src/shorts-response-filter.mjs
@@ -5,6 +5,9 @@ const SHORTS_RESPONSE_KEYS = [
   'shortsLockupViewModel'
 ];
 
+const TV_SHORTS_SHELF_RENDERER_TYPE = 'TVHTML5_SHELF_RENDERER_TYPE_SHORTS';
+const TV_SHORTS_ICON_TYPE = 'YOUTUBE_SHORTS_FILL_24';
+
 export function isShortsPath(value) {
   if (!value) return false;
 
@@ -39,6 +42,18 @@ function getShortsLinkNode(value) {
   });
 }
 
+function isTvShortsShelf(value) {
+  if (!value || typeof value !== 'object') return false;
+
+  const shelf = value.shelfRenderer;
+  if (!shelf || typeof shelf !== 'object') return false;
+
+  return (
+    shelf.tvhtml5ShelfRendererType === TV_SHORTS_SHELF_RENDERER_TYPE ||
+    shelf.icon?.iconType === TV_SHORTS_ICON_TYPE
+  );
+}
+
 export function isShortsResponseEntry(value) {
   if (!value || typeof value !== 'object') return false;
 
@@ -48,9 +63,10 @@ export function isShortsResponseEntry(value) {
     value.content;
 
   return Boolean(
-    SHORTS_RESPONSE_KEYS.some((key) =>
-      Object.prototype.hasOwnProperty.call(value, key)
-    ) ||
+    isTvShortsShelf(value) ||
+      SHORTS_RESPONSE_KEYS.some((key) =>
+        Object.prototype.hasOwnProperty.call(value, key)
+      ) ||
       content?.shortsLockupViewModel ||
       content?.reelItemRenderer ||
       getShortsLinkNode(value)

--- a/webapp/test/shorts-response-filter.test.mjs
+++ b/webapp/test/shorts-response-filter.test.mjs
@@ -37,6 +37,75 @@ test('removes Shorts entries from browse responses only', () => {
   ]);
 });
 
+test('removes YouTube TV Shorts shelves before the virtual list renders', () => {
+  const response = {
+    contents: {
+      tvBrowseRenderer: {
+        content: {
+          tvSurfaceContentRenderer: {
+            content: {
+              sectionListRenderer: {
+                contents: [
+                  {
+                    shelfRenderer: {
+                      tvhtml5ShelfRendererType: 'TVHTML5_SHELF_RENDERER_TYPE_STANDARD',
+                      icon: { iconType: 'VIDEO_LIBRARY_WHITE_24' }
+                    }
+                  },
+                  {
+                    shelfRenderer: {
+                      tvhtml5ShelfRendererType: 'TVHTML5_SHELF_RENDERER_TYPE_SHORTS',
+                      icon: { iconType: 'YOUTUBE_SHORTS_FILL_24' }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+
+  const contents =
+    response.contents.tvBrowseRenderer.content.tvSurfaceContentRenderer.content
+      .sectionListRenderer.contents;
+
+  assert.equal(isBrowseResponse(response), true);
+  assert.equal(stripShortsFromBrowseResponse(response), true);
+  assert.equal(contents.length, 1);
+  assert.equal(
+    contents[0].shelfRenderer.tvhtml5ShelfRendererType,
+    'TVHTML5_SHELF_RENDERER_TYPE_STANDARD'
+  );
+});
+
+test('recognizes the YouTube TV Shorts icon as a fallback shelf marker', () => {
+  const response = {
+    contents: {
+      items: [
+        {
+          shelfRenderer: {
+            icon: { iconType: 'YOUTUBE_SHORTS_FILL_24' }
+          }
+        },
+        {
+          shelfRenderer: {
+            icon: { iconType: 'VIDEO_LIBRARY_WHITE_24' }
+          }
+        }
+      ]
+    }
+  };
+
+  assert.equal(stripShortsFromBrowseResponse(response), true);
+  assert.equal(response.contents.items.length, 1);
+  assert.equal(
+    response.contents.items[0].shelfRenderer.icon.iconType,
+    'VIDEO_LIBRARY_WHITE_24'
+  );
+});
+
 test('does not classify direct player responses as browse responses', () => {
   const playerResponse = {
     videoDetails: { videoId: 'short-video' },


### PR DESCRIPTION
## Summary
- recognize YouTube TV Shorts shelves via `TVHTML5_SHELF_RENDERER_TYPE_SHORTS` and `YOUTUBE_SHORTS_FILL_24`
- remove the shelf from the browse response before YouTube builds its virtual list
- remove the old DOM/MutationObserver Shorts hiding implementation and its CSS
- add regression tests for the TV shelf markers

## Why
Direct Chrome testing against the current YouTube TV DOM showed that removing/hiding the rendered shelf creates virtual-list focus/layout problems. Filtering the browse JSON before rendering removes the shelf cleanly with no empty slot or ghost navigation.

## TV test
This PR intentionally keeps the sidebar untouched for now; it isolates the confirmed home-shelf fix for testing on real webOS/Cobalt hardware.