### PR TITLE
Run response filters before YouTube document load

### DIFF
--- a/cobalt-patches/cobalt-23.lts.6.patch
+++ b/cobalt-patches/cobalt-23.lts.6.patch
@@ -16,11 +16,12 @@ new file mode 100644
 index 000000000..7ea7d955
 --- /dev/null
 +++ b/cobalt/adblock/content/BUILD.gn
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,11 @@
 +copy("copy_adblock_web_files") {
 +  install_content = true
 +
 +  sources = [
++    "adblockPreload.js",
 +    "adblockMain.js",
 +    "adblockMain.css",
 +  ]
@@ -743,3 +744,89 @@ index a45ad09ca..90ba52c99 100644
              "options": [
                  {
                      "value": true,
+diff --git a/cobalt/browser/web_module.cc b/cobalt/browser/web_module.cc
+--- a/cobalt/browser/web_module.cc
++++ b/cobalt/browser/web_module.cc
+@@ -55,9 +55,11 @@
+ #include "cobalt/web/url.h"
+ #include "starboard/accessibility.h"
++#include "starboard/common/file.h"
+ #include "starboard/common/log.h"
+ #include "starboard/gles.h"
++#include "starboard/system.h"
+ 
+ #if defined(ENABLE_DEBUGGER)
+ #include "cobalt/debug/backend/debug_module.h"  // nogncheck
+@@ -75,6 +77,42 @@ namespace {
+ // deeper than this could be discarded, and will not be rendered.
+ const int kDOMMaxElementDepth = 32;
+ 
++bool ReadYtafPreloadScript(std::string* script, std::string* source_path) {
++  char content_dir[4096] = {0};
++  if (!SbSystemGetPath(kSbSystemPathContentDirectory, content_dir,
++                       static_cast<int>(sizeof(content_dir)))) {
++    LOG(ERROR) << "[YTAF] Cannot resolve content directory for preload";
++    return false;
++  }
++
++  const char* suffixes[] = {
++      "/web/adblock/adblockPreload.js",
++      "/adblock/adblockPreload.js",
++  };
++
++  for (const char* suffix : suffixes) {
++    const std::string path = std::string(content_dir) + suffix;
++    starboard::ScopedFile file(path.c_str(), kSbFileOpenOnly | kSbFileRead);
++    if (!file.IsValid()) {
++      continue;
++    }
++
++    const int64_t size = file.GetSize();
++    if (size <= 0 || size > 4 * 1024 * 1024) {
++      LOG(ERROR) << "[YTAF] Invalid preload script size: " << size;
++      return false;
++    }
++
++    script->resize(static_cast<size_t>(size));
++    const int bytes_read =
++        file.ReadAll(&(*script)[0], static_cast<int>(size));
++    if (bytes_read != size) {
++      script->clear();
++      continue;
++    }
++
++    *source_path = path;
++    return true;
++  }
++
++  LOG(ERROR) << "[YTAF] adblockPreload.js not found in content directory";
++  return false;
++}
++
+ void CacheUrlContent(SplashScreenCache* splash_screen_cache,
+                      const std::string& content,
+                      const base::Optional<std::string>& topic) {
+@@ -553,6 +591,23 @@ WebModule::Impl::Impl(web::Context* web_context, const ConstructionData& data)
+   web_context_->global_environment()->CreateGlobalObject(
+       window_, web_context_->environment_settings());
++
++  std::string ytaf_preload_script;
++  std::string ytaf_preload_path;
++  if (ReadYtafPreloadScript(&ytaf_preload_script, &ytaf_preload_path)) {
++    bool ytaf_preload_succeeded = false;
++    LOG(INFO) << "[YTAF] Executing early preload from " << ytaf_preload_path;
++    web_context_->script_runner()->Execute(
++        ytaf_preload_script,
++        base::SourceLocation(ytaf_preload_path, 1, 1),
++        false,
++        &ytaf_preload_succeeded);
++    if (ytaf_preload_succeeded) {
++      LOG(INFO) << "[YTAF] Early preload completed";
++    } else {
++      LOG(ERROR) << "[YTAF] Early preload execution failed";
++    }
++  }
++
+   DCHECK(web_context_->GetWindowOrWorkerGlobalScope()->IsWindow());
+   DCHECK(!web_context_->GetWindowOrWorkerGlobalScope()->IsDedicatedWorker());
+   DCHECK(!web_context_->GetWindowOrWorkerGlobalScope()->IsServiceWorker());

--- a/webapp/src/adblock-preload.js
+++ b/webapp/src/adblock-preload.js
@@ -1,0 +1,38 @@
+import { configRead } from './config.js';
+import {
+  isBrowseResponse,
+  stripShortsFromBrowseResponse
+} from './shorts-response-filter.mjs';
+
+if (!window.__ytafPreloadExecuted) {
+  window.__ytafPreloadExecuted = true;
+
+  let shortsEnabled = Boolean(configRead('enableShorts'));
+
+  document.addEventListener('ytaf-config-changed', (event) => {
+    if (event && event.detail && event.detail.key === 'enableShorts') {
+      shortsEnabled = Boolean(event.detail.value);
+    }
+  });
+
+  if (!window.__ytafShortsResponseFilterInstalled) {
+    window.__ytafShortsResponseFilterInstalled = true;
+
+    const previousParse = JSON.parse;
+    JSON.parse = function () {
+      const value = previousParse.apply(this, arguments);
+
+      if (
+        !shortsEnabled &&
+        isBrowseResponse(value) &&
+        stripShortsFromBrowseResponse(value)
+      ) {
+        console.log('[ytaf preload] Shorts blocker removed browse renderers');
+      }
+
+      return value;
+    };
+  }
+
+  console.info('[ytaf preload] Early hooks installed');
+}

--- a/webapp/src/shorts-block.js
+++ b/webapp/src/shorts-block.js
@@ -1,30 +1,6 @@
 import { checkboxTools } from './checkboxTools.js';
 import { configRead, configWrite } from './config.js';
 import { text as languageText } from './languages/index.js';
-import {
-  isBrowseResponse,
-  stripShortsFromBrowseResponse
-} from './shorts-response-filter.mjs';
-
-function installResponseFilter() {
-  if (window.__ytafShortsResponseFilterInstalled) return;
-  window.__ytafShortsResponseFilterInstalled = true;
-
-  const previousParse = JSON.parse;
-  JSON.parse = function () {
-    const value = previousParse.apply(this, arguments);
-
-    if (
-      !configRead('enableShorts') &&
-      isBrowseResponse(value) &&
-      stripShortsFromBrowseResponse(value)
-    ) {
-      console.log('Shorts blocker removed browse renderers !');
-    }
-
-    return value;
-  };
-}
 
 export function userScriptStartShortsBlockUI() {
   const control = document.querySelector('#__shorts');
@@ -47,5 +23,3 @@ export function userScriptStartShortsBlockUI() {
     configWrite('enableShorts', !newState);
   });
 }
-
-installResponseFilter();

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -42,6 +42,7 @@ module.exports = (env) => {
       },
 
       entry: {
+        adblockPreload: './src/adblock-preload.js',
         adblockMain: './src/adblock-main.js'
       },
       output: {


### PR DESCRIPTION
## Summary
- add a dedicated `adblockPreload.js` bundle for response-level hooks that must exist before YouTube initializes
- move the Shorts JSON response filter out of the late UI bundle
- keep the Shorts toggle live by syncing preload state through the existing `ytaf-config-changed` event
- execute the preload synchronously in Cobalt immediately after the Window global object is created and before the queued initial document load starts
- include the preload bundle in Cobalt's installed adblock content

## Why
The Shorts shelf filter works cleanly once a new `/youtubei/v1/browse` response arrives, but the initial Home response can already be parsed before the current `DispatchOnLoadEvent()` injection. Cobalt 23.lts.6 creates the Window/global object synchronously while `Window::StartDocumentLoad()` is queued with `PostTask`, which gives us a deterministic early hook point.

## TV test
A rebuilt Cobalt runtime is required. With Shorts blocking enabled, a cold app start should render Home without a Shorts shelf immediately, without first navigating in the sidebar.