### PR TITLE
Integrate YTAF, enable UHD, and stabilize app resume

### DIFF
--- a/cobalt-patches/cobalt-23.lts.6.patch
+++ b/cobalt-patches/cobalt-23.lts.6.patch
@@ -16,11 +16,12 @@ new file mode 100644
 index 000000000..7ea7d955
 --- /dev/null
 +++ b/cobalt/adblock/content/BUILD.gn
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,11 @@
 +copy("copy_adblock_web_files") {
 +  install_content = true
 +
 +  sources = [
++    "adblockPreload.js",
 +    "adblockMain.js",
 +    "adblockMain.css",
 +  ]
@@ -743,3 +744,89 @@ index a45ad09ca..90ba52c99 100644
              "options": [
                  {
                      "value": true,
+diff --git a/cobalt/browser/web_module.cc b/cobalt/browser/web_module.cc
+--- a/cobalt/browser/web_module.cc
++++ b/cobalt/browser/web_module.cc
+@@ -55,9 +55,11 @@
+ #include "cobalt/web/url.h"
+ #include "starboard/accessibility.h"
++#include "starboard/common/file.h"
+ #include "starboard/common/log.h"
+ #include "starboard/gles.h"
++#include "starboard/system.h"
+ 
+ #if defined(ENABLE_DEBUGGER)
+ #include "cobalt/debug/backend/debug_module.h"  // nogncheck
+@@ -75,6 +77,42 @@ namespace {
+ // deeper than this could be discarded, and will not be rendered.
+ const int kDOMMaxElementDepth = 32;
+ 
++bool ReadYtafPreloadScript(std::string* script, std::string* source_path) {
++  char content_dir[4096] = {0};
++  if (!SbSystemGetPath(kSbSystemPathContentDirectory, content_dir,
++                       static_cast<int>(sizeof(content_dir)))) {
++    LOG(ERROR) << "[YTAF] Cannot resolve content directory for preload";
++    return false;
++  }
++
++  const char* suffixes[] = {
++      "/web/adblock/adblockPreload.js",
++      "/adblock/adblockPreload.js",
++  };
++
++  for (const char* suffix : suffixes) {
++    const std::string path = std::string(content_dir) + suffix;
++    starboard::ScopedFile file(path.c_str(), kSbFileOpenOnly | kSbFileRead);
++    if (!file.IsValid()) {
++      continue;
++    }
++
++    const int64_t size = file.GetSize();
++    if (size <= 0 || size > 4 * 1024 * 1024) {
++      LOG(ERROR) << "[YTAF] Invalid preload script size: " << size;
++      return false;
++    }
++
++    script->resize(static_cast<size_t>(size));
++    const int bytes_read =
++        file.ReadAll(&(*script)[0], static_cast<int>(size));
++    if (bytes_read != size) {
++      script->clear();
++      continue;
++    }
++
++    *source_path = path;
++    return true;
++  }
++
++  LOG(ERROR) << "[YTAF] adblockPreload.js not found in content directory";
++  return false;
++}
++
+ void CacheUrlContent(SplashScreenCache* splash_screen_cache,
+                      const std::string& content,
+                      const base::Optional<std::string>& topic) {
+@@ -553,6 +591,23 @@ WebModule::Impl::Impl(web::Context* web_context, const ConstructionData& data)
+   web_context_->global_environment()->CreateGlobalObject(
+       window_, web_context_->environment_settings());
++
++  std::string ytaf_preload_script;
++  std::string ytaf_preload_path;
++  if (ReadYtafPreloadScript(&ytaf_preload_script, &ytaf_preload_path)) {
++    bool ytaf_preload_succeeded = false;
++    LOG(INFO) << "[YTAF] Executing early preload from " << ytaf_preload_path;
++    web_context_->script_runner()->Execute(
++        ytaf_preload_script,
++        base::SourceLocation(ytaf_preload_path, 1, 1),
++        false,
++        &ytaf_preload_succeeded);
++    if (ytaf_preload_succeeded) {
++      LOG(INFO) << "[YTAF] Early preload completed";
++    } else {
++      LOG(ERROR) << "[YTAF] Early preload execution failed";
++    }
++  }
++
+   DCHECK(web_context_->GetWindowOrWorkerGlobalScope()->IsWindow());
+   DCHECK(!web_context_->GetWindowOrWorkerGlobalScope()->IsDedicatedWorker());
+   DCHECK(!web_context_->GetWindowOrWorkerGlobalScope()->IsServiceWorker());

--- a/cobalt-platform/SDL-webOS-2.30.12-relaunch-sigcont.patch
+++ b/cobalt-platform/SDL-webOS-2.30.12-relaunch-sigcont.patch
@@ -1,0 +1,53 @@
+diff --git a/src/core/webos/SDL_webos_init.c b/src/core/webos/SDL_webos_init.c
+index 314751a..8a66e5a 100644
+--- a/src/core/webos/SDL_webos_init.c
++++ b/src/core/webos/SDL_webos_init.c
+@@ -1,6 +1,8 @@
+ #include "../../SDL_internal.h"
+ 
+ #ifdef __WEBOS__
++#include <signal.h>
++#include <unistd.h>
+ #include "../../events/SDL_events_c.h"
+ #include "../../video/SDL_sysvideo.h"
+ #include "SDL_error.h"
+@@ -208,6 +210,7 @@ static int lifecycleCallbackVersion1(LSHandle *sh, LSMessage *reply, HContext *c
+                 if (device->windows) {
+                     SDL_RaiseWindow(device->windows);
+                 }
++                kill(getpid(), SIGCONT);
+             }
+         }
+     }
+@@ -232,6 +235,7 @@ static int lifecycleCallbackVersion2(LSHandle *sh, LSMessage *reply, HContext *c
+                 if (device->windows) {
+                     SDL_RaiseWindow(device->windows);
+                 }
++                kill(getpid(), SIGCONT);
+             } else if (SDL_strncmp(message_buf.m_str, "close", message_buf.m_len) == 0) {
+                 SDL_SendQuit();
+             }
+diff --git a/src/video/wayland/SDL_waylandwebos.c b/src/video/wayland/SDL_waylandwebos.c
+index 20b9038..af40d4c 100644
+--- a/src/video/wayland/SDL_waylandwebos.c
++++ b/src/video/wayland/SDL_waylandwebos.c
+@@ -184,9 +184,6 @@ static void webos_shell_handle_state(void *data, struct wl_webos_shell_surface *
+ {
+     SDL_WindowData *d = data;
+     if (state == WL_WEBOS_SHELL_SURFACE_STATE_MINIMIZED) {
+-#ifdef SDL_WEBOS_HAVE_LIBHELPER
+-        HELPERS_HProcessAppState(3, NULL);
+-#endif
+         SDL_SendWindowEvent(d->sdlwindow, SDL_WINDOWEVENT_MINIMIZED, 0, 0);
+         SDL_SendAppEvent(SDL_APP_WILLENTERBACKGROUND);
+         SDL_SendAppEvent(SDL_APP_DIDENTERBACKGROUND);
+@@ -226,9 +223,6 @@ static void webos_shell_handle_state_about_to_change(void *data, struct wl_webos
+         return;
+     }
+     SDL_SendAppEvent(SDL_APP_WILLENTERBACKGROUND);
+-#ifdef SDL_WEBOS_HAVE_LIBHELPER
+-    HELPERS_HProcessAppState(1, NULL);
+-#endif
+ }
+ 
+ static void WindowHintsCallback(void *userdata, const char *name, const char *oldValue, const char *newValue)

--- a/cobalt-platform/cobalt-23.lts.6-demuxer-stop-race.patch
+++ b/cobalt-platform/cobalt-23.lts.6-demuxer-stop-race.patch
@@ -1,0 +1,26 @@
+diff --git a/cobalt/media/base/sbplayer_pipeline.cc b/cobalt/media/base/sbplayer_pipeline.cc
+index e14d0d07e..912895f3a 100644
+--- a/cobalt/media/base/sbplayer_pipeline.cc
++++ b/cobalt/media/base/sbplayer_pipeline.cc
+@@ -1284,15 +1284,16 @@ void SbPlayerPipeline::OnDemuxerStreamRead(
+     return;
+   }
+ 
++  // Stop() clears the streams while an asynchronous read callback may still
++  // be queued. Ignore that stale callback before dereferencing its stream.
++  if (!player_bridge_) {
++    return;
++  }
++
+   DemuxerStream* stream =
+       type == DemuxerStream::AUDIO ? audio_stream_ : video_stream_;
+   DCHECK(stream);
+ 
+-  // In case if Stop() has been called.
+-  if (!player_bridge_) {
+-    return;
+-  }
+-
+   if (status == DemuxerStream::kAborted) {
+     DCHECK(GetReadInProgress(type));
+     SetReadInProgress(type, false);

--- a/cobalt-platform/cobalt-23.lts.6-webos-lifecycle.patch
+++ b/cobalt-platform/cobalt-23.lts.6-webos-lifecycle.patch
@@ -1,0 +1,51 @@
+diff --git a/cobalt/system_window/system_window.cc b/cobalt/system_window/system_window.cc
+index d50749f2c..b9ac62cbd 100644
+--- a/cobalt/system_window/system_window.cc
++++ b/cobalt/system_window/system_window.cc
+@@ -276,7 +276,10 @@ void HandleInputEvent(const SbEvent* event) {
+     return;
+   }
+ 
++#if !defined(STARBOARD_WEBOS)
+   DCHECK(g_the_window);
++#endif
++
+   if (g_the_window != nullptr) {
+     g_the_window->HandleInputEvent(event);
+   } else {
+diff --git a/starboard/shared/signal/system_request_freeze.cc b/starboard/shared/signal/system_request_freeze.cc
+index 0aeda27ee..285954743 100644
+--- a/starboard/shared/signal/system_request_freeze.cc
++++ b/starboard/shared/signal/system_request_freeze.cc
+@@ -31,6 +31,17 @@ void FreezeDone(void* /*context*/) {
+   raise(SIGSTOP);
+ }
+ 
++void RequestFreeze() {
++#if defined(STARBOARD_WEBOS)
++  // Stay Concealed so the main event loop continues servicing SDL's Luna
++  // relaunch callback. The normal Frozen state stops that dispatch path,
++  // leaving SAM unable to bring the retained process to the foreground.
++  return;
++#else
++  starboard::shared::starboard::Application::Get()->Freeze(NULL, &FreezeDone);
++#endif
++}
++
+ void SbSystemRequestFreeze() {
+ #if SB_IS(EVERGREEN_COMPATIBLE) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
+   if (starboard::loader_app::IsPendingRestart()) {
+@@ -39,11 +50,11 @@ void SbSystemRequestFreeze() {
+     starboard::shared::starboard::Application::Get()->Stop(0);
+   } else {
+     // Let the platform decide if directly transit into Frozen.
+-    starboard::shared::starboard::Application::Get()->Freeze(NULL, &FreezeDone);
++    RequestFreeze();
+   }
+ #else
+   // Let the platform decide if directly transit into Frozen.
+-  starboard::shared::starboard::Application::Get()->Freeze(NULL, &FreezeDone);
++  RequestFreeze();
+ #endif  // SB_IS(EVERGREEN_COMPATIBLE) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
+ }
+ #endif  // SB_API_VERSION >= 13

--- a/cobalt-platform/cobalt-23.lts.6-webos-uhd.patch
+++ b/cobalt-platform/cobalt-23.lts.6-webos-uhd.patch
@@ -1,0 +1,24 @@
+diff --git a/starboard/linux/shared/media_is_video_supported.cc b/starboard/linux/shared/media_is_video_supported.cc
+index 53829ee16..7c732823a 100644
+--- a/starboard/linux/shared/media_is_video_supported.cc
++++ b/starboard/linux/shared/media_is_video_supported.cc
+@@ -76,6 +76,18 @@ bool SbMediaIsVideoSupported(SbMediaVideoCodec video_codec,
+           (video_codec == kSbMediaVideoCodecVp9)
+ #endif
+          ) &&
+-         frame_width <= 1920 && frame_height <= 1080 &&
++#if defined(STARBOARD_WEBOS)
++         // The starterless webOS port sends VP9 and AV1 elementary streams to
++         // Starfish's hardware decoder.  Keep the software-oriented 1080p
++         // ceiling for AVC, but advertise UHD for the codecs handled by that
++         // hardware path.  HDR bit depth and colour metadata were validated
++         // above before reaching this resolution check.
++         ((frame_width <= 1920 && frame_height <= 1080) ||
++          ((video_codec == kSbMediaVideoCodecVp9 ||
++            video_codec == kSbMediaVideoCodecAv1) &&
++           frame_width <= 3840 && frame_height <= 2160)) &&
++#else
++         frame_width <= 1920 && frame_height <= 1080 &&
++#endif
+          bitrate <= kSbMediaMaxVideoBitrateInBitsPerSecond && fps <= 60;
+ }

--- a/cobalt-platform/webos/arm/application_sdl.cc
+++ b/cobalt-platform/webos/arm/application_sdl.cc
@@ -135,6 +135,11 @@ void ApplicationSdl::Initialize() {
   SDL_SetHint(SDL_HINT_WEBOS_REGISTER_APP, "1");
   SDL_SetHint(SDL_HINT_WEBOS_ACCESS_POLICY_KEYS_BACK, "1");
   SDL_SetHint(SDL_HINT_WEBOS_ACCESS_POLICY_KEYS_EXIT, "1");
+  // SDL disables the screen saver by default.  On webOS that registers a
+  // process-wide wake lock whose response vetoes every screen-saver request,
+  // including while this app is only semi-full preloaded.  Start uninhibited;
+  // the Starfish decoder below controls inhibition during active playback.
+  SDL_SetHint(SDL_HINT_VIDEO_ALLOW_SCREENSAVER, "1");
   if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) != 0) {
     SB_LOG(ERROR) << "SDL_Init failed: " << SDL_GetError();
     Stop(10);
@@ -251,15 +256,6 @@ SbWindow ApplicationSdl::CreateWindow(const SbWindowOptions* options) {
   window_ = new SbWindowPrivate(sdl_window, info.info.wl.display,
                                 info.info.wl.egl_window, width, height,
                                 video_pixel_ratio);
-  const char* exported_window = SDL_webOSCreateExportedWindow(
-      SDL_WEBOS_EXPORED_WINDOW_TYPE_VIDEO);
-  if (exported_window) {
-    exported_window_id_ = exported_window;
-    SB_LOG(INFO) << "Created exported video window " << exported_window_id_;
-  } else {
-    SB_LOG(ERROR) << "SDL_webOSCreateExportedWindow failed: "
-                  << SDL_GetError();
-  }
   return window_;
 }
 
@@ -275,6 +271,9 @@ bool ApplicationSdl::DestroyWindow(SbWindow window) {
     SDL_webOSDestroyExportedWindow(exported_window_id_.c_str());
     exported_window_id_.clear();
   }
+  SDL_EnableScreenSaver();
+  exported_video_clients_ = 0;
+  video_screen_saver_inhibited_ = false;
   exported_geometry_valid_ = false;
   egl_surface_ = nullptr;
   egl_config_id_ = 0;
@@ -282,6 +281,64 @@ bool ApplicationSdl::DestroyWindow(SbWindow window) {
   delete window;
   window_ = kSbWindowInvalid;
   return true;
+}
+
+bool ApplicationSdl::AcquireExportedVideoWindow() {
+  ScopedLock lock(exported_geometry_mutex_);
+  if (!SbWindowIsValid(window_)) {
+    return false;
+  }
+  if (!exported_window_id_.empty()) {
+    ++exported_video_clients_;
+    return true;
+  }
+
+  const char* exported_window = SDL_webOSCreateExportedWindow(
+      SDL_WEBOS_EXPORED_WINDOW_TYPE_VIDEO);
+  if (!exported_window) {
+    SB_LOG(ERROR) << "SDL_webOSCreateExportedWindow failed: "
+                  << SDL_GetError();
+    return false;
+  }
+  exported_window_id_ = exported_window;
+  exported_video_clients_ = 1;
+  exported_geometry_valid_ = false;
+  SDL_DisableScreenSaver();
+  video_screen_saver_inhibited_ = true;
+  SB_LOG(INFO) << "Created exported video window " << exported_window_id_;
+  return true;
+}
+
+void ApplicationSdl::ReleaseExportedVideoWindow() {
+  ScopedLock lock(exported_geometry_mutex_);
+  if (exported_video_clients_ <= 0) {
+    return;
+  }
+  --exported_video_clients_;
+  if (exported_video_clients_ != 0 || exported_window_id_.empty()) {
+    return;
+  }
+  SDL_webOSDestroyExportedWindow(exported_window_id_.c_str());
+  SB_LOG(INFO) << "Destroyed exported video window " << exported_window_id_;
+  exported_window_id_.clear();
+  exported_geometry_valid_ = false;
+  SDL_EnableScreenSaver();
+  video_screen_saver_inhibited_ = false;
+}
+
+void ApplicationSdl::SetVideoPaused(bool paused) {
+  ScopedLock lock(exported_geometry_mutex_);
+  if (!sdl_initialized_ || exported_window_id_.empty()) {
+    return;
+  }
+  const bool inhibit_screen_saver = !paused;
+  if (video_screen_saver_inhibited_ == inhibit_screen_saver) {
+    return;
+  }
+  video_screen_saver_inhibited_ = inhibit_screen_saver;
+  inhibit_screen_saver ? SDL_DisableScreenSaver() : SDL_EnableScreenSaver();
+  SB_LOG(INFO) << "Screen saver " << (paused ? "allowed" : "inhibited")
+               << " for video pause state.";
 }
 
 void* ApplicationSdl::GetNativeDisplay() const {

--- a/cobalt-platform/webos/arm/application_sdl.h
+++ b/cobalt-platform/webos/arm/application_sdl.h
@@ -44,8 +44,8 @@ class ApplicationSdl : public starboard::QueueApplication {
                    int y,
                    int width,
                    int height) override;
-  bool IsStartImmediate() override { return true; }
-  bool IsPreloadImmediate() override { return false; }
+  bool IsStartImmediate() override { return !HasPreloadSwitch(); }
+  bool IsPreloadImmediate() override { return HasPreloadSwitch(); }
   void Initialize() override;
   void Teardown() override;
   bool MayHaveSystemEvents() override;

--- a/cobalt-platform/webos/arm/application_sdl.h
+++ b/cobalt-platform/webos/arm/application_sdl.h
@@ -26,6 +26,9 @@ class ApplicationSdl : public starboard::QueueApplication {
   void* GetEglSurface() const { return egl_surface_; }
   int GetEglConfigId() const { return egl_config_id_; }
   const std::string& GetExportedWindowId() const { return exported_window_id_; }
+  bool AcquireExportedVideoWindow();
+  void ReleaseExportedVideoWindow();
+  void SetVideoPaused(bool paused);
   void SetVideoResolution(int width, int height) {
     video_width_.store(width);
     video_height_.store(height);
@@ -68,6 +71,8 @@ class ApplicationSdl : public starboard::QueueApplication {
   SDL_Rect last_video_destination_{0, 0, 0, 0};
   Mutex exported_geometry_mutex_;
   bool exported_geometry_valid_ = false;
+  int exported_video_clients_ = 0;
+  bool video_screen_saver_inhibited_ = false;
   Uint32 wake_event_type_;
 };
 

--- a/cobalt-platform/webos/arm/main.cc
+++ b/cobalt-platform/webos/arm/main.cc
@@ -41,12 +41,22 @@ extern "C" SB_EXPORT_PLATFORM int main(int argc, char** argv) {
   starboard::shared::webos::ApplicationSdl application;
   std::vector<char*> cobalt_argv;
   cobalt_argv.push_back(argv[0]);
+  bool preload = false;
   for (int i = 1; i < argc; ++i) {
     if (argv[i] && argv[i][0] == '{' &&
         std::strstr(argv[i], "\"@system_native_app\"") != nullptr) {
+      if (std::strstr(argv[i], "\"preload\":\"semi-full\"") != nullptr ||
+          std::strstr(argv[i], "\"event\":\"preload\"") != nullptr) {
+        preload = true;
+      }
       continue;
     }
     cobalt_argv.push_back(argv[i]);
+  }
+  char preload_switch[] = "--preload";
+  if (preload) {
+    cobalt_argv.push_back(preload_switch);
+    std::fprintf(stderr, "Translating webOS hidden preload launch.\n");
   }
   int result = 0;
   {

--- a/cobalt-platform/webos/arm/starfish_video_decoder.cc
+++ b/cobalt-platform/webos/arm/starfish_video_decoder.cc
@@ -52,6 +52,10 @@ StarfishVideoDecoder::~StarfishVideoDecoder() {
     decoder_thread_.reset();
   }
   CancelPendingJobs();
+  if (exported_window_acquired_) {
+    ApplicationSdl::Get()->ReleaseExportedVideoWindow();
+    exported_window_acquired_ = false;
+  }
 }
 
 void StarfishVideoDecoder::Initialize(const DecoderStatusCB& decoder_status_cb,
@@ -61,12 +65,19 @@ void StarfishVideoDecoder::Initialize(const DecoderStatusCB& decoder_status_cb,
   SB_DCHECK(error_cb);
   decoder_status_cb_ = decoder_status_cb;
   error_cb_ = error_cb;
+  exported_window_acquired_ =
+      ApplicationSdl::Get()->AcquireExportedVideoWindow();
+  if (!exported_window_acquired_) {
+    ReportError("SDL did not create a webOS exported video window.");
+    return;
+  }
   decoder_thread_.reset(new starboard::player::JobThread(
       "starfish_video_decoder", 0, kSbThreadPriorityHigh));
 }
 
 void StarfishVideoDecoder::SetPause(bool pause) {
   pause_requested_.store(pause);
+  ApplicationSdl::Get()->SetVideoPaused(pause);
   if (decoder_thread_) {
     decoder_thread_->Schedule(std::bind(
         &StarfishVideoDecoder::ApplyPlaybackStateOnDecoderThread, this));
@@ -79,6 +90,7 @@ void StarfishVideoDecoder::SetPlaybackRate(double playback_rate) {
   }
   playback_rate_millionths_.store(
       static_cast<int>(playback_rate * 1000000.0));
+  ApplicationSdl::Get()->SetVideoPaused(playback_rate <= 0.0);
   if (decoder_thread_) {
     decoder_thread_->Schedule(std::bind(
         &StarfishVideoDecoder::ApplyPlaybackStateOnDecoderThread, this));

--- a/cobalt-platform/webos/arm/starfish_video_decoder.h
+++ b/cobalt-platform/webos/arm/starfish_video_decoder.h
@@ -66,6 +66,7 @@ class StarfishVideoDecoder
   Mutex pipeline_state_mutex_;
   ConditionVariable pipeline_state_condition_;
   bool pipeline_loaded_ = false;
+  bool exported_window_acquired_ = false;
   bool stream_ended_ = false;
   bool eos_output_ = false;
   int video_width_ = 0;

--- a/docs/starterless-sdl-investigation.md
+++ b/docs/starterless-sdl-investigation.md
@@ -46,6 +46,13 @@ The older SDK SDL shared binary requires no newer glibc symbol than
 `GLIBC_2.9`. The newer webOSbrew SDL is statically linked into the probe to
 keep the test package independent of a particular TV's installed SDL version.
 
+Starterless application resume additionally requires
+`cobalt-platform/SDL-webOS-2.30.12-relaunch-sigcont.patch` to be applied when
+building that SDL archive. The patch keeps SDL's Luna lifecycle callback in
+control of conceal/relaunch transitions and sends a process-directed
+`SIGCONT`, allowing Cobalt's main thread to resume even though the callback
+runs on a worker thread that blocks lifecycle signals.
+
 The SDK also contains the public Starfish media header and a link-time
 `libplayerAPIs.so.1` stub. The real implementation is provided by the TV. This
 is important because it gives a starterless port access to LG's hardware video

--- a/docs/starterless-sdl-investigation.md
+++ b/docs/starterless-sdl-investigation.md
@@ -53,6 +53,13 @@ control of conceal/relaunch transitions and sends a process-directed
 `SIGCONT`, allowing Cobalt's main thread to resume even though the callback
 runs on a worker thread that blocks lifecycle signals.
 
+The SDL archive must be configured with
+`-DSDL_WEBOS_BROKEN_ABI=ON`, matching the webOSbrew `SDL_config.h` shipped
+with the bundle. This adds webOS's `inputSource` member to SDL input events.
+Building the library without the option while compiling Cobalt against the
+webOS headers shifts the keyboard-event fields and makes remote navigation
+unresponsive.
+
 The SDK also contains the public Starfish media header and a link-time
 `libplayerAPIs.so.1` stub. The real implementation is provided by the TV. This
 is important because it gives a starterless port access to LG's hardware video

--- a/scripts/build-starterless-cobalt-docker.sh
+++ b/scripts/build-starterless-cobalt-docker.sh
@@ -19,7 +19,9 @@ if ! docker volume inspect "$sdk_volume" >/dev/null 2>&1; then
   exit 3
 fi
 
+make -C "$repo_root" npm-docker
 "$repo_root/scripts/install-webos-starboard-platform.sh" "$cobalt_root"
+"$repo_root/scripts/install-ytaf-cobalt-assets.sh" "$cobalt_root"
 mkdir -p "$(dirname "$build_log")"
 
 echo "Starting the long Cobalt webos-arm build with $parallel jobs."
@@ -33,7 +35,7 @@ docker run --rm --platform linux/amd64 \
   -e WEBOS_SDK_ROOT=/sdk/arm-webos-linux-gnueabi_sdk-buildroot \
   -e SDL2_BUNDLE_DIR=/sdl \
   cobalt-build-evergreen:latest \
-  sh -c "gn --script-executable=python3 gen '$out_dir' --args='target_platform=\"webos-arm\" build_type=\"$build_type\" target_cpu=\"arm\" sb_api_version=13 is_clang=false' && ninja -v -j '$parallel' -C '$out_dir' cobalt" \
+  sh -c "git config --global --add safe.directory /code && gn --script-executable=python3 gen '$out_dir' --args='target_platform=\"webos-arm\" build_type=\"$build_type\" target_cpu=\"arm\" sb_api_version=13 is_clang=false' && ninja -v -j '$parallel' -C '$out_dir' cobalt" \
   2>&1 | tee "$build_log"
 
 echo "Cobalt binary: $cobalt_root/$out_dir/cobalt"

--- a/scripts/install-webos-starboard-platform.sh
+++ b/scripts/install-webos-starboard-platform.sh
@@ -15,6 +15,7 @@ gcc_compat_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-gcc.patch"
 video_fallback_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-video-fallback.patch"
 vp9_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-vp9.patch"
 av1_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-av1.patch"
+uhd_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-uhd.patch"
 dav1d_api_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-dav1d-api.patch"
 starfish_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-starfish.patch"
 pulse_soname_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-pulse-soname.patch"
@@ -87,6 +88,12 @@ if ! grep -q 'dav1d handles AV1' \
   "$cobalt_root/starboard/linux/shared/media_is_video_supported.cc"; then
   git -C "$cobalt_root" apply --check "$av1_patch"
   git -C "$cobalt_root" apply "$av1_patch"
+fi
+
+if ! grep -q 'Starfish.*hardware decoder' \
+  "$cobalt_root/starboard/linux/shared/media_is_video_supported.cc"; then
+  git -C "$cobalt_root" apply --check "$uhd_patch"
+  git -C "$cobalt_root" apply "$uhd_patch"
 fi
 
 if ! grep -q 'dav1d-webos-official/public' \

--- a/scripts/install-webos-starboard-platform.sh
+++ b/scripts/install-webos-starboard-platform.sh
@@ -22,6 +22,8 @@ pulse_soname_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-pulse-sonam
 pulse_tuning_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-pulse-tuning.patch"
 external_video_seek_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-external-video-seek.patch"
 external_video_controls_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-external-video-controls.patch"
+lifecycle_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-lifecycle.patch"
+demuxer_stop_race_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-demuxer-stop-race.patch"
 
 if [[ ! -d "$cobalt_root/.git" || ! -f "$platforms_file" ]]; then
   echo "Not a Cobalt source tree: $cobalt_root" >&2
@@ -130,6 +132,18 @@ if ! grep -q 'virtual void SetPlaybackRate' \
   "$cobalt_root/starboard/shared/starboard/player/filter/video_decoder_internal.h"; then
   git -C "$cobalt_root" apply --check "$external_video_controls_patch"
   git -C "$cobalt_root" apply "$external_video_controls_patch"
+fi
+
+if ! grep -q 'Stay Concealed so the main event loop' \
+  "$cobalt_root/starboard/shared/signal/system_request_freeze.cc"; then
+  git -C "$cobalt_root" apply --check "$lifecycle_patch"
+  git -C "$cobalt_root" apply "$lifecycle_patch"
+fi
+
+if ! grep -q 'Ignore that stale callback before dereferencing its stream' \
+  "$cobalt_root/cobalt/media/base/sbplayer_pipeline.cc"; then
+  git -C "$cobalt_root" apply --check "$demuxer_stop_race_patch"
+  git -C "$cobalt_root" apply "$demuxer_stop_race_patch"
 fi
 
 echo "Installed webos-arm Starboard platform into: $platform_target"

--- a/scripts/install-ytaf-cobalt-assets.sh
+++ b/scripts/install-ytaf-cobalt-assets.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cobalt_root="${1:-$repo_root/workdir/cobalt-23.lts.6}"
+webapp_output="${WEBAPP_OUTPUT_DIR:-$repo_root/webapp/output}"
+app_patch="$repo_root/cobalt-patches/cobalt-23.lts.6.patch"
+content_target="$cobalt_root/cobalt/adblock/content"
+
+if [[ ! -d "$cobalt_root/.git" ]]; then
+  echo "Not a Cobalt source tree: $cobalt_root" >&2
+  exit 2
+fi
+
+for asset in adblockMain.js adblockMain.css adblockPreload.js; do
+  if [[ ! -f "$webapp_output/$asset" ]]; then
+    echo "Missing built web asset: $webapp_output/$asset" >&2
+    echo "Run 'make npm-docker' before building starterless Cobalt." >&2
+    exit 3
+  fi
+done
+
+if [[ ! -f "$cobalt_root/cobalt/adblock/BUILD.gn" ]]; then
+  git -C "$cobalt_root" apply --check --recount "$app_patch"
+  git -C "$cobalt_root" apply --recount "$app_patch"
+fi
+
+if ! grep -q 'adblockPreload.js' \
+  "$cobalt_root/cobalt/adblock/content/BUILD.gn"; then
+  echo "The Cobalt tree contains an older YTAF patch without preload support." >&2
+  echo "Use a clean Cobalt 23.lts.6 checkout and rerun this script." >&2
+  exit 4
+fi
+
+mkdir -p "$content_target"
+for asset in adblockMain.js adblockMain.css adblockPreload.js; do
+  cp -p "$webapp_output/$asset" "$content_target/$asset"
+done
+
+echo "Installed current YTAF Cobalt patch and web assets into: $cobalt_root"

--- a/starterless-cobalt/appinfo.json
+++ b/starterless-cobalt/appinfo.json
@@ -1,6 +1,6 @@
 {
   "id": "youtube.leanback.v4",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "vendor": "RF1705",
   "type": "native",
   "main": "cobalt",

--- a/starterless-cobalt/appinfo.json
+++ b/starterless-cobalt/appinfo.json
@@ -1,6 +1,6 @@
 {
   "id": "youtube.leanback.v4",
-  "version": "2.0.13",
+  "version": "2.0.1",
   "vendor": "RF1705",
   "type": "native",
   "main": "cobalt",

--- a/starterless-cobalt/appinfo.json
+++ b/starterless-cobalt/appinfo.json
@@ -1,6 +1,6 @@
 {
   "id": "youtube.leanback.v4",
-  "version": "2.0.1",
+  "version": "2.0.13",
   "vendor": "RF1705",
   "type": "native",
   "main": "cobalt",

--- a/webapp/src/adblock-main.js
+++ b/webapp/src/adblock-main.js
@@ -6,7 +6,7 @@ import './domrect-polyfill';
 import './json-stringify-hook';
 import './ui.js';
 
-import { handleInitialLaunch, handleLaunch, waitForChildAdd } from './utils';
+import { handleInitialLaunch, handleLaunch } from './utils';
 import { configRead } from './config.js';
 import { userScriptStartUI } from './ui.js';
 import { userScriptStartSponsoredQrCodeUI } from './sponsored-qr-code-ui.js';
@@ -29,40 +29,6 @@ document.addEventListener(
   },
   true
 );
-
-// This IIFE is to keep the video element fill the entire window so that screensaver doesn't kick in.
-(async () => {
-  /** @type {HTMLVideoElement} */
-  const video = await waitForChildAdd(
-    document.body,
-    (node) => node instanceof HTMLVideoElement
-  );
-
-  const playerCtrlObs = new MutationObserver(() => {
-    const style = video.style;
-
-    const targetWidth = `${window.innerWidth}px`;
-    const targetHeight = `${window.innerHeight}px`;
-    const targetLeft = '0px';
-    // YT uses a negative top to hide player when not in use. Don't know why but let's not affect it.
-    const targetTop =
-      style.top === `-${window.innerHeight}px` ? style.top : '0px';
-
-    /**
-     * Check to see if identical before assignment as some webOS versions will trigger a mutation
-     * mutation event even if the assignment effectively does nothing, leading to an infinite loop.
-     */
-    style.width !== targetWidth && (style.width = targetWidth);
-    style.height !== targetHeight && (style.height = targetHeight);
-    style.left !== targetLeft && (style.left = targetLeft);
-    style.top !== targetTop && (style.top = targetTop);
-  });
-
-  playerCtrlObs.observe(video, {
-    attributes: true,
-    attributeFilter: ['style']
-  });
-})();
 
 function startOptionalHook(configKey, startHook) {
   const enabled = configRead(configKey);

--- a/webapp/src/adblock-preload.js
+++ b/webapp/src/adblock-preload.js
@@ -1,0 +1,38 @@
+import { configRead } from './config.js';
+import {
+  isBrowseResponse,
+  stripShortsFromBrowseResponse
+} from './shorts-response-filter.mjs';
+
+if (!window.__ytafPreloadExecuted) {
+  window.__ytafPreloadExecuted = true;
+
+  let shortsEnabled = Boolean(configRead('enableShorts'));
+
+  document.addEventListener('ytaf-config-changed', (event) => {
+    if (event && event.detail && event.detail.key === 'enableShorts') {
+      shortsEnabled = Boolean(event.detail.value);
+    }
+  });
+
+  if (!window.__ytafShortsResponseFilterInstalled) {
+    window.__ytafShortsResponseFilterInstalled = true;
+
+    const previousParse = JSON.parse;
+    JSON.parse = function () {
+      const value = previousParse.apply(this, arguments);
+
+      if (
+        !shortsEnabled &&
+        isBrowseResponse(value) &&
+        stripShortsFromBrowseResponse(value)
+      ) {
+        console.log('[ytaf preload] Shorts blocker removed browse renderers');
+      }
+
+      return value;
+    };
+  }
+
+  console.info('[ytaf preload] Early hooks installed');
+}

--- a/webapp/src/shorts-block.js
+++ b/webapp/src/shorts-block.js
@@ -1,30 +1,6 @@
 import { checkboxTools } from './checkboxTools.js';
 import { configRead, configWrite } from './config.js';
 import { text as languageText } from './languages/index.js';
-import {
-  isBrowseResponse,
-  stripShortsFromBrowseResponse
-} from './shorts-response-filter.mjs';
-
-function installResponseFilter() {
-  if (window.__ytafShortsResponseFilterInstalled) return;
-  window.__ytafShortsResponseFilterInstalled = true;
-
-  const previousParse = JSON.parse;
-  JSON.parse = function () {
-    const value = previousParse.apply(this, arguments);
-
-    if (
-      !configRead('enableShorts') &&
-      isBrowseResponse(value) &&
-      stripShortsFromBrowseResponse(value)
-    ) {
-      console.log('Shorts blocker removed browse renderers !');
-    }
-
-    return value;
-  };
-}
 
 export function userScriptStartShortsBlockUI() {
   const control = document.querySelector('#__shorts');
@@ -47,5 +23,3 @@ export function userScriptStartShortsBlockUI() {
     configWrite('enableShorts', !newState);
   });
 }
-
-installResponseFilter();

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -42,6 +42,7 @@ module.exports = (env) => {
       },
 
       entry: {
+        adblockPreload: './src/adblock-preload.js',
         adblockMain: './src/adblock-main.js'
       },
       output: {


### PR DESCRIPTION
## Summary

- merge the current mainline preload and Shorts-response filtering work into the starterless beta
- build and install the YTAF UI and preload assets automatically before compiling Cobalt
- advertise VP9 and AV1 through 3840x2160 at 60 fps for the Starfish hardware decoder while retaining the 1080p AVC ceiling
- translate hidden webOS preload launches into Cobalt's preload lifecycle
- keep the concealed Cobalt event loop available to service SAM relaunches
- resume Cobalt with a process-directed `SIGCONT` from SDL's Luna lifecycle callback
- ignore asynchronous demuxer callbacks that arrive after player teardown
- allow the webOS screen saver while Cobalt is preloaded, idle, or paused, while retaining inhibition during active playback

## Lifecycle failure analysis

The retained Cobalt process originally entered the Frozen state and stopped servicing SDL's Luna callback. Earlier attempts to raise `SIGCONT` from that callback were thread-directed; the signal landed on a Luna worker thread where lifecycle signals are blocked. Keeping the webOS process Concealed and using `kill(getpid(), SIGCONT)` lets the main Cobalt thread process unfreeze, reveal, and focus normally.

Repeated switching also exposed a separate teardown race. `SbPlayerPipeline::Stop()` cleared the audio/video streams while an already queued `OnDemuxerStreamRead()` callback could still run. Its stream assertion produced `Check failed: stream`, followed by `SIGILL` and an apparent application restart. The callback now verifies that the player bridge still exists before dereferencing the cleared stream.

## Screen-saver failure analysis

SDL-webOS disables the screen saver by default and registers a process-wide `<appId>.wakelock`. That wake lock remained active during webOS semi-full preload and vetoed every screen-saver request. The app now starts with the screen saver allowed and creates the exported video window only when the Starfish decoder is initialized.

Active playback inhibits the screen saver. Both Cobalt pause representations—`SetPause(true)` and playback rate zero—release that inhibition, and playback resume restores it. Releasing the decoder or destroying the window also restores the default allowed state. The old JavaScript loop that continuously forced video geometry to suppress the screen saver has been removed.

## Validation

- production webpack build completed successfully
- all current web test files pass
- all new patches apply cleanly to pristine pinned Cobalt 23.lts.6 and SDL-webOS 2.30.12 sources
- Cobalt 23.lts.6 webOS ARM build completed and linked with VP9/libvpx, AV1/dav1d, SDL, Starfish, and the YTAF assets
- generated IPK passed container verification; the source manifest remains at the existing 2.0.1 beta version
- physically tested on an LG webOS TV
- confirmed 2160p60 HDR playback for content previously limited to 1080p
- confirmed startup-page switching and YTAF integration
- repeatedly switched away from and back to YouTube during playback; the retained process resumes at the correct playback position without relaunching or hitting the demuxer assertion
- confirmed the screen saver remains inhibited during playback and activates while idle or paused, using both the normal idle timeout and a forced screen-saver request

## Scope

The UHD extension is limited to VP9 and AV1 handled by the Starfish hardware path. H.264 and other software-oriented formats retain the existing 1920x1080 limit. Existing frame-rate, bitrate, bit-depth, HDR metadata, and codec validation remains in place.

Diagnostic dumps, device logs, investigation notes, generated test packages, and build trees are intentionally excluded from the pull request.
