### PR TITLE
Preserve Shorts preload JSON parser hook

### DIFF
--- a/webapp/src/adblock-preload.js
+++ b/webapp/src/adblock-preload.js
@@ -1,6 +1,7 @@
 import { configRead } from './config.js';
 import {
   isBrowseResponse,
+  isGuideResponse,
   stripShortsFromBrowseResponse
 } from './shorts-response-filter.mjs';
 
@@ -35,10 +36,10 @@ if (!window.__ytafPreloadExecuted) {
 
         if (
           !shortsEnabled &&
-          isBrowseResponse(value) &&
+          (isBrowseResponse(value) || isGuideResponse(value)) &&
           stripShortsFromBrowseResponse(value)
         ) {
-          console.log('[ytaf preload] Shorts blocker removed browse renderers');
+          console.log('[ytaf preload] Shorts blocker removed response entries');
         }
 
         return value;

--- a/webapp/src/adblock-preload.js
+++ b/webapp/src/adblock-preload.js
@@ -18,20 +18,51 @@ if (!window.__ytafPreloadExecuted) {
   if (!window.__ytafShortsResponseFilterInstalled) {
     window.__ytafShortsResponseFilterInstalled = true;
 
-    const previousParse = JSON.parse;
-    JSON.parse = function () {
-      const value = previousParse.apply(this, arguments);
+    const descriptor = Object.getOwnPropertyDescriptor(JSON, 'parse');
+    const nativeParse = JSON.parse;
+    let downstreamParse = nativeParse;
+    let parsing = false;
 
-      if (
-        !shortsEnabled &&
-        isBrowseResponse(value) &&
-        stripShortsFromBrowseResponse(value)
-      ) {
-        console.log('[ytaf preload] Shorts blocker removed browse renderers');
+    function ytafParse() {
+      if (parsing) {
+        return nativeParse.apply(this, arguments);
       }
 
-      return value;
-    };
+      parsing = true;
+
+      try {
+        const value = downstreamParse.apply(this, arguments);
+
+        if (
+          !shortsEnabled &&
+          isBrowseResponse(value) &&
+          stripShortsFromBrowseResponse(value)
+        ) {
+          console.log('[ytaf preload] Shorts blocker removed browse renderers');
+        }
+
+        return value;
+      } finally {
+        parsing = false;
+      }
+    }
+
+    if (!descriptor || descriptor.configurable) {
+      Object.defineProperty(JSON, 'parse', {
+        configurable: true,
+        enumerable: descriptor ? descriptor.enumerable : false,
+        get() {
+          return ytafParse;
+        },
+        set(parser) {
+          if (typeof parser === 'function' && parser !== ytafParse) {
+            downstreamParse = parser;
+          }
+        }
+      });
+    } else {
+      JSON.parse = ytafParse;
+    }
   }
 
   console.info('[ytaf preload] Early hooks installed');

--- a/webapp/src/adblock-preload.js
+++ b/webapp/src/adblock-preload.js
@@ -10,19 +10,53 @@ if (!window.__ytafPreloadExecuted) {
 
   let shortsEnabled = Boolean(configRead('enableShorts'));
 
-  document.addEventListener('ytaf-config-changed', (event) => {
-    if (event && event.detail && event.detail.key === 'enableShorts') {
-      shortsEnabled = Boolean(event.detail.value);
-    }
-  });
-
   if (!window.__ytafShortsResponseFilterInstalled) {
     window.__ytafShortsResponseFilterInstalled = true;
 
     const descriptor = Object.getOwnPropertyDescriptor(JSON, 'parse');
     const nativeParse = JSON.parse;
+    const nativeStringify = JSON.stringify;
     let downstreamParse = nativeParse;
     let parsing = false;
+    let originalGuideResponseJson = null;
+
+    function captureGuideResponse(value) {
+      try {
+        originalGuideResponseJson = nativeStringify.call(JSON, value);
+      } catch (error) {
+        console.warn('[ytaf preload] Failed to preserve guide response', error);
+      }
+    }
+
+    function applyGuideShortsState() {
+      if (!originalGuideResponseJson) return false;
+
+      const appElement = document.querySelector('ytlr-app');
+      const app = appElement && appElement.__instance;
+      if (!app || typeof app.K !== 'function') return false;
+
+      let guideResponse;
+      try {
+        guideResponse = nativeParse.call(JSON, originalGuideResponseJson);
+      } catch (error) {
+        console.warn('[ytaf preload] Failed to restore guide response', error);
+        return false;
+      }
+
+      if (!shortsEnabled) {
+        stripShortsFromBrowseResponse(guideResponse);
+      }
+
+      app.K({ guideResponse });
+      return true;
+    }
+
+    document.addEventListener('ytaf-config-changed', (event) => {
+      if (event && event.detail && event.detail.key === 'enableShorts') {
+        shortsEnabled = Boolean(event.detail.value);
+        applyGuideShortsState();
+      }
+    });
 
     function ytafParse() {
       if (parsing) {
@@ -33,10 +67,15 @@ if (!window.__ytafPreloadExecuted) {
 
       try {
         const value = downstreamParse.apply(this, arguments);
+        const guideResponse = isGuideResponse(value);
+
+        if (guideResponse) {
+          captureGuideResponse(value);
+        }
 
         if (
           !shortsEnabled &&
-          (isBrowseResponse(value) || isGuideResponse(value)) &&
+          (isBrowseResponse(value) || guideResponse) &&
           stripShortsFromBrowseResponse(value)
         ) {
           console.log('[ytaf preload] Shorts blocker removed response entries');

--- a/webapp/src/shorts-response-filter.mjs
+++ b/webapp/src/shorts-response-filter.mjs
@@ -54,6 +54,27 @@ function isTvShortsShelf(value) {
   );
 }
 
+function hasGuideRenderer(value, depth = 0) {
+  if (!value || typeof value !== 'object' || depth > 6) return false;
+
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasGuideRenderer(entry, depth + 1));
+  }
+
+  if (
+    value.guideRenderer ||
+    value.guideSectionRenderer ||
+    value.guideSubscriptionsSectionRenderer ||
+    value.guideEntryRenderer
+  ) {
+    return true;
+  }
+
+  return Object.keys(value).some((key) =>
+    hasGuideRenderer(value[key], depth + 1)
+  );
+}
+
 export function isShortsResponseEntry(value) {
   if (!value || typeof value !== 'object') return false;
 
@@ -113,4 +134,11 @@ export function isBrowseResponse(value) {
         value.onResponseReceivedActions ||
         value.onResponseReceivedEndpoints)
   );
+}
+
+export function isGuideResponse(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  if (value.videoDetails || value.streamingData) return false;
+
+  return hasGuideRenderer(value);
 }

--- a/webapp/src/shorts-response-filter.mjs
+++ b/webapp/src/shorts-response-filter.mjs
@@ -29,6 +29,7 @@ function getShortsLinkNode(value) {
 
   const endpoints = [
     value.navigationEndpoint,
+    value.guideEntryRenderer?.navigationEndpoint,
     value.onSelectCommand,
     value.command,
     value.tileRenderer?.onSelectCommand,

--- a/webapp/src/shorts-response-filter.mjs
+++ b/webapp/src/shorts-response-filter.mjs
@@ -7,6 +7,9 @@ const SHORTS_RESPONSE_KEYS = [
 
 const TV_SHORTS_SHELF_RENDERER_TYPE = 'TVHTML5_SHELF_RENDERER_TYPE_SHORTS';
 const TV_SHORTS_ICON_TYPE = 'YOUTUBE_SHORTS_FILL_24';
+const TV_SHORTS_GUIDE_SOURCE =
+  'REEL_WATCH_ENDPOINT_SOURCE_SHORTS_PIVOT_BAR';
+const TV_SHORTS_OVERLAY_STYLE = 'REEL_PLAYER_OVERLAY_STYLE_SHORTS';
 
 export function isShortsPath(value) {
   if (!value) return false;
@@ -55,6 +58,22 @@ function isTvShortsShelf(value) {
   );
 }
 
+function isTvShortsGuideEntry(value) {
+  if (!value || typeof value !== 'object') return false;
+
+  const entry = value.guideEntryRenderer;
+  if (!entry || typeof entry !== 'object') return false;
+
+  const reelWatchEndpoint = entry.navigationEndpoint?.reelWatchEndpoint;
+
+  return Boolean(
+    entry.icon?.iconType === TV_SHORTS_ICON_TYPE ||
+      reelWatchEndpoint?.watchEndpointSource === TV_SHORTS_GUIDE_SOURCE ||
+      reelWatchEndpoint?.overlay?.reelPlayerOverlayRenderer?.style ===
+        TV_SHORTS_OVERLAY_STYLE
+  );
+}
+
 function hasGuideRenderer(value, depth = 0) {
   if (!value || typeof value !== 'object' || depth > 6) return false;
 
@@ -86,6 +105,7 @@ export function isShortsResponseEntry(value) {
 
   return Boolean(
     isTvShortsShelf(value) ||
+      isTvShortsGuideEntry(value) ||
       SHORTS_RESPONSE_KEYS.some((key) =>
         Object.prototype.hasOwnProperty.call(value, key)
       ) ||

--- a/webapp/test/shorts-response-filter.test.mjs
+++ b/webapp/test/shorts-response-filter.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   isBrowseResponse,
+  isGuideResponse,
   isShortsPath,
   stripShortsFromBrowseResponse
 } from '../src/shorts-response-filter.mjs';
@@ -114,6 +115,7 @@ test('does not classify direct player responses as browse responses', () => {
   };
 
   assert.equal(isBrowseResponse(playerResponse), false);
+  assert.equal(isGuideResponse(playerResponse), false);
 });
 
 test('removes FEshorts navigation entries but keeps ordinary browse entries', () => {
@@ -140,4 +142,52 @@ test('removes FEshorts navigation entries but keeps ordinary browse entries', ()
       }
     }
   ]);
+});
+
+test('removes Shorts from the YouTube TV guide before navigation renders', () => {
+  const response = {
+    items: [
+      {
+        guideSectionRenderer: {
+          items: [
+            {
+              guideEntryRenderer: {
+                title: { simpleText: 'Home' },
+                navigationEndpoint: {
+                  browseEndpoint: { browseId: 'FEwhat_to_watch' }
+                }
+              }
+            },
+            {
+              guideEntryRenderer: {
+                title: { simpleText: 'Shorts' },
+                navigationEndpoint: {
+                  browseEndpoint: { browseId: 'FEshorts' }
+                }
+              }
+            },
+            {
+              guideEntryRenderer: {
+                title: { simpleText: 'Subscriptions' },
+                navigationEndpoint: {
+                  browseEndpoint: { browseId: 'FEsubscriptions' }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  };
+
+  assert.equal(isBrowseResponse(response), false);
+  assert.equal(isGuideResponse(response), true);
+  assert.equal(stripShortsFromBrowseResponse(response), true);
+
+  const items = response.items[0].guideSectionRenderer.items;
+  assert.equal(items.length, 2);
+  assert.deepEqual(
+    items.map((item) => item.guideEntryRenderer.navigationEndpoint.browseEndpoint.browseId),
+    ['FEwhat_to_watch', 'FEsubscriptions']
+  );
 });

--- a/webapp/test/shorts-response-filter.test.mjs
+++ b/webapp/test/shorts-response-filter.test.mjs
@@ -152,26 +152,38 @@ test('removes Shorts from the YouTube TV guide before navigation renders', () =>
           items: [
             {
               guideEntryRenderer: {
-                title: { simpleText: 'Home' },
                 navigationEndpoint: {
-                  browseEndpoint: { browseId: 'FEwhat_to_watch' }
-                }
+                  browseEndpoint: { browseId: 'FEtopics' }
+                },
+                icon: { iconType: 'WHAT_TO_WATCH' },
+                formattedTitle: { simpleText: 'Startseite' }
               }
             },
             {
               guideEntryRenderer: {
-                title: { simpleText: 'Shorts' },
                 navigationEndpoint: {
-                  browseEndpoint: { browseId: 'FEshorts' }
-                }
+                  reelWatchEndpoint: {
+                    overlay: {
+                      reelPlayerOverlayRenderer: {
+                        style: 'REEL_PLAYER_OVERLAY_STYLE_SHORTS'
+                      }
+                    },
+                    watchEndpointSource:
+                      'REEL_WATCH_ENDPOINT_SOURCE_SHORTS_PIVOT_BAR',
+                    videoType: 'REEL_VIDEO_TYPE_VIDEO'
+                  }
+                },
+                icon: { iconType: 'YOUTUBE_SHORTS_FILL_24' },
+                formattedTitle: { simpleText: 'Shorts' }
               }
             },
             {
               guideEntryRenderer: {
-                title: { simpleText: 'Subscriptions' },
                 navigationEndpoint: {
                   browseEndpoint: { browseId: 'FEsubscriptions' }
-                }
+                },
+                icon: { iconType: 'SUBSCRIPTIONS' },
+                formattedTitle: { simpleText: 'Abos' }
               }
             }
           ]
@@ -187,7 +199,7 @@ test('removes Shorts from the YouTube TV guide before navigation renders', () =>
   const items = response.items[0].guideSectionRenderer.items;
   assert.equal(items.length, 2);
   assert.deepEqual(
-    items.map((item) => item.guideEntryRenderer.navigationEndpoint.browseEndpoint.browseId),
-    ['FEwhat_to_watch', 'FEsubscriptions']
+    items.map((item) => item.guideEntryRenderer.icon.iconType),
+    ['WHAT_TO_WATCH', 'SUBSCRIPTIONS']
   );
 });


### PR DESCRIPTION
## Summary
- keep the early Shorts response filter installed even if YouTube replaces `JSON.parse` during bootstrap
- preserve YouTube's replacement parser as the downstream parser instead of blocking it
- filter YouTube TV Shorts shelves and guide entries before they reach the virtual list
- recognize the real TV guide markers (`YOUTUBE_SHORTS_FILL_24` / `REEL_WATCH_ENDPOINT_SOURCE_SHORTS_PIVOT_BAR`)
- preserve the original guide response and refresh `ytlr-app` state through YouTube's own `__instance.K({ guideResponse })` path when the Shorts toggle changes
- restore Shorts instantly when the blocker is disabled without a page/app reload or direct DOM manipulation

## Why
Runtime logs confirmed `adblockPreload.js` executes before the first `/youtubei/v1/browse` request, but YouTube replaces `JSON.parse` later during bootstrap. A temporary parser-restoration test proved this was why the early response filter stopped working.

Direct DOM removal was also unsuitable for YouTube TV because the sidebar and Home rows are backed by a virtual list; deleting rendered elements can leave ghost focus positions. Filtering source responses avoids that problem.

The final toggle handling uses YouTube TV's own guide state update path instead of forcing a reload. The original guide response is retained, filtered copies are supplied while blocking is enabled, and the unfiltered response is restored when blocking is disabled.

## Validation
- CI passes
- physically tested on LG webOS/Cobalt 23.lts.6 / Starboard 13
- cold start with blocker enabled: no Shorts Home shelf and no Shorts sidebar entry
- blocker disabled: Shorts sidebar entry returns immediately and Home Shorts return on the next browse refresh
- blocker re-enabled: Shorts sidebar entry disappears immediately
- sidebar focus/navigation remains smooth with no ghost slots
- normal navigation and playback remain unchanged