### PR TITLE
Fix Starfish seek preroll deadlock

### DIFF
--- a/cobalt-platform/webos/arm/starfish_video_decoder.cc
+++ b/cobalt-platform/webos/arm/starfish_video_decoder.cc
@@ -456,9 +456,10 @@ void StarfishVideoDecoder::ApplyPlaybackStateOnDecoderThread() {
 
   const bool should_pause = pause_requested_.load() || playback_rate <= 0.0;
   if (should_pause) {
-    // pauseAtDecodeTime needs one real frame to finish the platform preroll.
-    // Pausing earlier can leave the decoder permanently in LoadingState.
-    if (first_frame_presented_.load() && !pause_issued_) {
+    // During a seek Cobalt holds playback at rate 0 until video preroll reaches
+    // the target timestamp.  Pausing on an earlier decoded frame deadlocks the
+    // pipeline: no later frame can reach the target and release the preroll.
+    if (preroll_frame_sent_.load() && !pause_issued_) {
       const bool accepted = media_api_->Pause();
       SB_LOG(INFO) << "Starfish Pause() -> "
                    << (accepted ? "accepted" : "refused");
@@ -612,6 +613,10 @@ void StarfishVideoDecoder::HandlePlayerEvent(int type,
                    << frame_time << " target=" << target_time;
       Schedule(std::bind(decoder_status_cb_, kNeedMoreInput,
                          scoped_refptr<VideoFrame>(new VideoFrame(frame_time))));
+      if (decoder_thread_) {
+        decoder_thread_->Schedule(std::bind(
+            &StarfishVideoDecoder::ApplyPlaybackStateOnDecoderThread, this));
+      }
     }
     return;
   }


### PR DESCRIPTION
## Summary

- keep the Starfish decoder running while a seek is still advancing toward its preroll target
- honor Cobalt's temporary zero playback rate only after the target frame completes video preroll
- reapply the requested playback state when preroll completes

## Why

Manual quality changes create a new player and seek it to the current playback position. During that seek, Cobalt temporarily sets the playback rate to zero. The decoder previously paused after the first decoded frame, even when that frame preceded the requested timestamp. That prevented later frames from reaching the seek target, so video preroll never completed and playback remained frozen.

This change gates the pause on completed video preroll rather than merely receiving the first frame.

## Validation

- Docker starterless Cobalt build completed successfully
- packaged IPK passed ownership normalization and container verification
- automatic UHD playback works on a physical webOS TV
- manual switching among 1080p, 1440p, and 4K works on a physical webOS TV
- app switching and paused-video screen saver behavior remain functional in the tested build

## Scope

The earlier YTAF asset integration has been removed from this PR because it overlaps the maintainer-owned starterless implementation in #73. This PR now changes only `starfish_video_decoder.cc`.

Local diagnostic logs and core dumps are intentionally excluded.