### PR TITLE
Synchronize Starfish video preroll with PulseAudio

### DIFF
--- a/cobalt-platform/cobalt-23.lts.6-webos-external-video-preroll-sync.patch
+++ b/cobalt-platform/cobalt-23.lts.6-webos-external-video-preroll-sync.patch
@@ -1,0 +1,34 @@
+diff --git a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
++++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+@@ -176,8 +176,11 @@ bool FilterBasedPlayerWorkerHandler::Init(
+         std::bind(&FilterBasedPlayerWorkerHandler::OnPrerolled, this,
+                   kSbMediaTypeVideo),
+         std::bind(&FilterBasedPlayerWorkerHandler::OnEnded, this,
+                   kSbMediaTypeVideo));
+-    video_renderer_->SetPause(paused_);
++    // Hold an external video pipeline at its preroll target until the audio
++    // media-time provider is ready. Otherwise video can start its independent
++    // hardware clock well before PulseAudio starts.
++    video_renderer_->SetPause(true);
+     video_renderer_->SetPlaybackRate(playback_rate_);
+   }
+ 
+@@ -202,6 +205,7 @@ bool FilterBasedPlayerWorkerHandler::Seek(SbTime seek_to_time, int ticket) {
+ 
+   media_time_provider_->Pause();
+   if (video_renderer_) {
++    video_renderer_->SetPause(true);
+     video_renderer_->Seek(seek_to_time);
+   }
+   media_time_provider_->Seek(seek_to_time);
+@@ -456,6 +460,9 @@ void FilterBasedPlayerWorkerHandler::OnPrerolled(SbMediaType media_type) {
+     if (!paused_) {
+       media_time_provider_->Play();
+     }
++    if (video_renderer_) {
++      video_renderer_->SetPause(paused_);
++    }
+   }
+ }
+ 

--- a/scripts/install-webos-starboard-platform.sh
+++ b/scripts/install-webos-starboard-platform.sh
@@ -22,6 +22,7 @@ pulse_soname_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-pulse-sonam
 pulse_tuning_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-pulse-tuning.patch"
 external_video_seek_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-external-video-seek.patch"
 external_video_controls_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-external-video-controls.patch"
+external_video_preroll_sync_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-external-video-preroll-sync.patch"
 lifecycle_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-webos-lifecycle.patch"
 demuxer_stop_race_patch="$repo_root/cobalt-platform/cobalt-23.lts.6-demuxer-stop-race.patch"
 
@@ -132,6 +133,12 @@ if ! grep -q 'virtual void SetPlaybackRate' \
   "$cobalt_root/starboard/shared/starboard/player/filter/video_decoder_internal.h"; then
   git -C "$cobalt_root" apply --check "$external_video_controls_patch"
   git -C "$cobalt_root" apply "$external_video_controls_patch"
+fi
+
+if ! grep -q 'Hold an external video pipeline at its preroll target' \
+  "$cobalt_root/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc"; then
+  git -C "$cobalt_root" apply --check "$external_video_preroll_sync_patch"
+  git -C "$cobalt_root" apply "$external_video_preroll_sync_patch"
 fi
 
 if ! grep -q 'Stay Concealed so the main event loop' \


### PR DESCRIPTION
## Summary
- hold the external Starfish video pipeline at its preroll target while PulseAudio prepares
- keep video paused during seeks until both streams finish preroll
- release video with the configured pause state when presentation begins

## Why
Starfish owns an independent hardware video clock, while PulseAudio is Cobalt's media-time provider. Starting Starfish as soon as video data arrives can let video advance before audio is ready, producing an intermittent fixed A/V offset. This keeps Starfish decoding through preroll, pauses it at the target frame, and releases it alongside the audio clock.

## Validation
- built Cobalt 23.lts.6 webos-arm successfully from the cleaned patch set
- packaged and verified a valid starterless IPK
- passed both webapp tests
- tested on a physical LG webOS TV across multiple videos, seeks, and player recreations
- reviewed roughly 50 minutes of diagnostic playback: all eight prerolls completed, with no audio-renderer underruns, Starfish failures, fatal checks, or crash signals
- confirmed app switching, UI controls, resolution switching, and screensaver behavior remain functional

Temporary clock telemetry used during diagnosis is intentionally excluded from this PR.