### PR TITLE
Render SponsorBlock markers on current YouTube TV DOM

### DIFF
--- a/webapp/src/sponsorblock.js
+++ b/webapp/src/sponsorblock.js
@@ -171,8 +171,40 @@ function getClosest(element, selector) {
   return null;
 }
 
-function getMarkerHost(progressBar) {
+function getMarkerHost(progressBar, track) {
+  // Marker direkt im Track verankern. Der aeussere Wrapper verliert sein
+  // inline "position: relative", sobald YouTube die Leiste neu rendert; die
+  // absolut positionierten Marker springen dann an eine falsche Stelle.
+  // Im Track selbst ist der Versatz konstant 0/0.
+  if (track) return track;
   return getClosest(progressBar, 'ytlr-multi-markers-player-bar-renderer') || progressBar;
+}
+
+// Volle Breite der Fortschrittsleiste. Aktuelle YouTube-TV-Builds liefern
+// kein "segment" mehr, sondern "cue-ranges" bzw. "slider" mit gleicher
+// Geometrie. Reihenfolge = Prioritaet, damit aeltere DOMs unveraendert bleiben.
+const TRACK_IDOM_KEYS = ['segment', 'cue-ranges', 'slider'];
+
+function findTrackElement(progressBar) {
+  const children = progressBar.children || [];
+
+  for (let keyIndex = 0; keyIndex < TRACK_IDOM_KEYS.length; keyIndex += 1) {
+    const trackKey = TRACK_IDOM_KEYS[keyIndex];
+
+    // Der aktuelle YouTube-DOM:
+    // progress-bar enthält den Track als direktes Kind.
+    for (let childIndex = 0; childIndex < children.length; childIndex += 1) {
+      if (children[childIndex].getAttribute?.('idomkey') === trackKey) {
+        return children[childIndex];
+      }
+    }
+
+    // Fallback, falls YouTube noch einen Wrapper ergänzt.
+    const nested = progressBar.querySelector(`[idomkey="${trackKey}"]`);
+    if (nested) return nested;
+  }
+
+  return null;
 }
 
 function findProgressBarParts() {
@@ -194,22 +226,7 @@ function findProgressBarParts() {
       if (visited.includes(progressBar)) continue;
       visited.push(progressBar);
 
-      let segment = null;
-      const children = progressBar.children || [];
-
-      // Der aktuelle YouTube-DOM:
-      // progress-bar enthält segment als direktes Kind.
-      for (let childIndex = 0; childIndex < children.length; childIndex += 1) {
-        if (children[childIndex].getAttribute?.('idomkey') === 'segment') {
-          segment = children[childIndex];
-          break;
-        }
-      }
-
-      // Fallback, falls YouTube noch einen Wrapper ergänzt.
-      if (!segment) {
-        segment = progressBar.querySelector('[idomkey="segment"]');
-      }
+      const segment = findTrackElement(progressBar);
       if (!segment) continue;
 
       const rect = progressBar.getBoundingClientRect();
@@ -491,7 +508,7 @@ class SponsorBlockController {
   }
 
   findExistingOverlay(progressBar) {
-    const host = getMarkerHost(progressBar);
+    const host = getMarkerHost(progressBar, this.progressSegment);
     const connected =
       this.markerNodes.length &&
       this.markerHost === host &&
@@ -657,7 +674,7 @@ class SponsorBlockController {
       return;
     }
 
-    const host = getMarkerHost(this.progressBar);
+    const host = getMarkerHost(this.progressBar, this.progressSegment);
     if (!host) {
       this.markerStatus = 'waiting-for-stable-anchor';
       return;


### PR DESCRIPTION
## Problem

SponsorBlock segments are fetched and skipped correctly, but no coloured markers appear on the seek bar. Because skipping keeps working, the fetch path and category config are clearly fine — only the overlay is missing.

## Root cause

Two separate defects, the first masking the second.

**1. The track element is never found.** `findProgressBarParts()` requires each candidate to contain a child with `idomkey="segment"`:

```js
if (!segment) {
  segment = progressBar.querySelector('[idomkey="segment"]');
}
if (!segment) continue;
```

Current YouTube TV builds do not emit `segment` at all. Instrumenting the live DOM on a 2025 LG C5 while the seek bar was on screen:

```
[0] n=0   ytlr-multi-markers-player-bar-renderer
[1] n=0   ytlr-multi-markers-player-bar-renderer [idomkey="progress-bar"]
[2] n=0   [idomkey="progress-bar"].afTAdb
[3] n=2   [idomkey="progress-bar"]
    -> ytlr-redux-connect-ytlr-progress-bar[progress-bar]  1728x102  seg=NO
    -> ytlr-progress-bar[progress-bar]                     1728x102  seg=NO
idomkeys: {"time-counter":1,"progress-bar":2,"slider":1,"time-label":2,"elapsedTime":1,"progress":1}
```

The bar itself resolves fine with real geometry, but both candidates are skipped by the `continue` and the controller settles on `waiting-for-progress-bar`. `ytlr-multi-markers-player-bar-renderer` is gone entirely and the `.afTAdb` class has rotated, so selectors 0–2 no longer match either.

The subtree shows the replacement keys:

```
HOST ytlr-progress-bar[progress-bar]   96,639  1728x102
 div[slider]                           96,710  1728x9    <- full track
  div.tkZjRe                           96,710    60x9    <- buffered
  div.STXq3b                           96,710    28x9    <- elapsed (28/1728 = 21/1301)
  div[cue-ranges]                      96,710  1728x9    <- YouTube's own marker container
 div[time-label]                       96,663  1728x30
```

`cue-ranges` and `slider` are full-width and constant; `progress`/`STXq3b` track elapsed time and would be the wrong anchor.

**2. Markers land in the wrong place once they do draw.** `drawOverlay()` appends them to `getMarkerHost(progressBar)` and offsets them by the track's position relative to that host (here +71px). That only holds while the host keeps the inline `position: relative` this code sets, and YouTube's incremental DOM drops it on re-render — so the absolutely positioned markers resolve against a different containing block and drift away from the bar. On my set they rendered over the Ask/Save buttons.

## Fix

- `TRACK_IDOM_KEYS = ['segment', 'cue-ranges', 'slider']`, tried in order by the new `findTrackElement()` helper. `segment` stays first, so any DOM that still has it resolves exactly as before — this is additive for older builds.
- `getMarkerHost()` takes the resolved track and anchors into it. Host and track rects become identical, the offset is a constant 0/0, and correctness no longer depends on an ancestor's inline style surviving a re-render.

This also matches the existing width assumption: the old code already used the track rect's width as the full bar width when positioning markers, so anchoring to that same element is consistent.

## Verification

Device: LG OLED77C56LA (C5, 2025), webOS 10.3.1, firmware 33.31.68, board `O22A3_DVB`.

Markers render on the bar, aligned to their segment times, and stay aligned across seeks and controls hide/show. Verified on-device by applying the equivalent change to the shipped bundle, since that TV cannot run the current release; the source change here builds clean and carries into the compiled output.

```
npx eslint src/sponsorblock.js   # clean
npm test                          # 10/10 pass
npm run build                     # webpack compiled successfully
```

Prettier is unchanged by this patch — `webapp/src/sponsorblock.js` already differs from `prettier --check` on `main`, and none of the added lines are affected, so the diff stays minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnhSUAWrhbgVR3ennfVN4f
