### PR TITLE
Apply the existing IPK ownership normalization to the standard package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           grep -F 'RF1705/YouTube-webos-images.git' Makefile
           grep -F 'youtube-official-1.1.5.tar.gz' Makefile
           python3 scripts/verify-pjtr-starter.py --help
+          python3 scripts/normalize-ipk-ownership.py --help
 
       - name: Build injected web app
         working-directory: webapp

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,13 @@ PACKAGE_SOURCE_FORMAT?=auto
 IPK_MEMBER_MTIME?=$(shell date +%s)
 PACKAGE_MTIME_NORMALIZER?=scripts/normalize-package-mtime.py
 IPK_CONTAINER_VERIFIER?=scripts/verify-ipk-container.py
+# Cobalt runs as gid 5000 on the TV. webOS resets app directories to 775 on
+# reboot, so the payload must be group-owned by 5000 with group-writable
+# directories or the app loses write access to its own storage.
+IPK_OWNERSHIP_NORMALIZER?=scripts/normalize-ipk-ownership.py
+IPK_OWNER_UID?=0
+IPK_OWNER_GID?=5000
+IPK_DIR_MODE?=775
 PACKAGE_SB_API_VERSION?=$(shell strings $(WORKDIR)/image/usr/palm/applications/$(PACKAGE_NAME_OFFICIAL)/cobalt 2>/dev/null | grep sb_api | jq -r '.sb_api_version' | grep -v null || strings $(WORKDIR)/package/usr/palm/applications/$(PACKAGE_NAME_OFFICIAL)/cobalt 2>/dev/null | grep sb_api | jq -r '.sb_api_version' | grep -v null)
 YTAF_DEBUG?=0
 YTAF_DEBUG_ENABLED=$(filter 1 true yes on,$(YTAF_DEBUG))
@@ -436,6 +443,11 @@ ares-package-docker: docker-make.ares-package
 .PRECIOUS: $(PACKAGE_TARGET)
 $(PACKAGE_TARGET): FORCE $(WORKDIR)/image/usr/palm/applications/$(PACKAGE_NAME_OFFICIAL)/cobalt $(WORKDIR)/cobalt $(WORKDIR)/ipk/content/app/cobalt/content/web/adblock ares-package-docker
 	mkdir -p $(dir $@)
+	python3 $(IPK_OWNERSHIP_NORMALIZER) \
+	  --uid $(IPK_OWNER_UID) \
+	  --gid $(IPK_OWNER_GID) \
+	  --directory-mode $(IPK_DIR_MODE) \
+	  $(WORKDIR)/ipk-output/$(PACKAGE_IPK_BUILD)
 	python3 $(IPK_CONTAINER_VERIFIER) $(WORKDIR)/ipk-output/$(PACKAGE_IPK_BUILD)
 	mv $(WORKDIR)/ipk-output/$(PACKAGE_IPK_BUILD) $@
 	@echo "Package can be installed with:"

--- a/scripts/normalize-ipk-ownership.py
+++ b/scripts/normalize-ipk-ownership.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Normalize ownership metadata in a webOS IPK without extracting its files."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import io
+import os
+from pathlib import Path
+import re
+import stat
+import tarfile
+import tempfile
+
+
+AR_MAGIC = b"!<arch>\n"
+AR_HEADER_SIZE = 60
+EXPECTED_MEMBERS = ("debian-binary", "control.tar.gz", "data.tar.gz")
+TAR_BLOCK_SIZE = 512
+PAX_OWNERSHIP = re.compile(rb"(?:^|\n)[0-9]+ (?:uid|gid|uname|gname)=")
+
+
+def parse_decimal(field: bytes, label: str) -> int:
+    try:
+        return int(field.decode("ascii").strip())
+    except ValueError as error:
+        raise ValueError(f"Invalid {label} field: {field!r}") from error
+
+
+def parse_octal(field: bytes, label: str) -> int:
+    if field and field[0] & 0x80:
+        raise ValueError(f"Base-256 {label} fields are not supported")
+    value = field.rstrip(b"\0 ").lstrip(b" ") or b"0"
+    try:
+        return int(value, 8)
+    except ValueError as error:
+        raise ValueError(f"Invalid {label} field: {field!r}") from error
+
+
+def format_octal(value: int, width: int, label: str) -> bytes:
+    if value < 0:
+        raise ValueError(f"{label} must not be negative")
+    digits = f"{value:0{width - 2}o}".encode("ascii")
+    if len(digits) > width - 2:
+        raise ValueError(f"{label} does not fit in a tar header: {value}")
+    return digits + b" \0"
+
+
+def read_ar_members(contents: bytes) -> list[tuple[str, bytes, bytes]]:
+    if not contents.startswith(AR_MAGIC):
+        raise ValueError("Missing ar archive magic")
+
+    offset = len(AR_MAGIC)
+    members: list[tuple[str, bytes, bytes]] = []
+    while offset < len(contents):
+        header = contents[offset : offset + AR_HEADER_SIZE]
+        if len(header) != AR_HEADER_SIZE or header[58:60] != b"`\n":
+            raise ValueError(f"Invalid ar member header at byte {offset}")
+
+        raw_name = header[0:16].decode("ascii").rstrip()
+        if raw_name.endswith("/"):
+            raise ValueError(f"GNU ar member name is not webOS-compatible: {raw_name}")
+        size = parse_decimal(header[48:58], f"{raw_name} size")
+        data_start = offset + AR_HEADER_SIZE
+        data_end = data_start + size
+        if data_end > len(contents):
+            raise ValueError(f"IPK member {raw_name} extends beyond the archive")
+
+        members.append((raw_name, header, contents[data_start:data_end]))
+        offset = data_end + (size % 2)
+
+    order = tuple(name for name, _, _ in members)
+    if order != EXPECTED_MEMBERS:
+        raise ValueError(
+            f"Unexpected IPK members: {list(order)}; expected {list(EXPECTED_MEMBERS)}"
+        )
+    return members
+
+
+def normalize_tar(
+    compressed_tar: bytes, uid: int, gid: int, directory_mode: int
+) -> tuple[bytes, int]:
+    try:
+        contents = bytearray(gzip.decompress(compressed_tar))
+        with tarfile.open(fileobj=io.BytesIO(contents), mode="r:") as archive:
+            archive.getmembers()
+    except (gzip.BadGzipFile, EOFError, OSError, tarfile.TarError) as error:
+        raise ValueError(f"Invalid data.tar.gz: {error}") from error
+
+    offset = 0
+    entry_count = 0
+    zero_blocks = 0
+    while offset + TAR_BLOCK_SIZE <= len(contents):
+        block = contents[offset : offset + TAR_BLOCK_SIZE]
+        if not any(block):
+            zero_blocks += 1
+            offset += TAR_BLOCK_SIZE
+            if zero_blocks == 2:
+                break
+            continue
+        zero_blocks = 0
+
+        size = parse_octal(block[124:136], "tar member size")
+        type_flag = bytes(block[156:157])
+        payload_start = offset + TAR_BLOCK_SIZE
+        payload_end = payload_start + size
+        if payload_end > len(contents):
+            raise ValueError("Tar member extends beyond data.tar.gz")
+        if type_flag in (b"x", b"g") and PAX_OWNERSHIP.search(
+            bytes(contents[payload_start:payload_end])
+        ):
+            raise ValueError(
+                "PAX ownership overrides are not supported; refusing a partial normalization"
+            )
+
+        header = bytearray(block)
+        if type_flag in (b"5", b"D"):
+            header[100:108] = format_octal(directory_mode, 8, "directory mode")
+        header[108:116] = format_octal(uid, 8, "uid")
+        header[116:124] = format_octal(gid, 8, "gid")
+
+        # Empty owner names make extractors use the numeric ids above instead
+        # of resolving names inherited from the packaging workstation.
+        header[265:297] = b"\0" * 32
+        header[297:329] = b"\0" * 32
+        header[148:156] = b" " * 8
+        header[148:156] = format_octal(sum(header), 8, "tar checksum")
+        contents[offset : offset + TAR_BLOCK_SIZE] = header
+
+        entry_count += 1
+        offset = payload_start + ((size + TAR_BLOCK_SIZE - 1) // TAR_BLOCK_SIZE) * TAR_BLOCK_SIZE
+
+    if zero_blocks < 2:
+        raise ValueError("data.tar.gz is missing the tar end marker")
+
+    return gzip.compress(bytes(contents), compresslevel=9, mtime=0), entry_count
+
+
+def replace_ar_member(contents: bytes, member_name: str, replacement: bytes) -> bytes:
+    members = read_ar_members(contents)
+    output = bytearray(AR_MAGIC)
+    found = False
+    for name, original_header, data in members:
+        header = bytearray(original_header)
+        if name == member_name:
+            data = replacement
+            size_field = f"{len(data):<10}".encode("ascii")
+            if len(size_field) != 10:
+                raise ValueError(f"IPK member {name} is too large for an ar header")
+            header[48:58] = size_field
+            found = True
+        output.extend(header)
+        output.extend(data)
+        if len(data) % 2:
+            output.extend(b"\n")
+    if not found:
+        raise ValueError(f"Missing IPK member: {member_name}")
+    return bytes(output)
+
+
+def normalize_package(
+    package: Path, uid: int, gid: int, directory_mode: int
+) -> int:
+    original = package.read_bytes()
+    members = read_ar_members(original)
+    data_tar = next(data for name, _, data in members if name == "data.tar.gz")
+    normalized_tar, entry_count = normalize_tar(data_tar, uid, gid, directory_mode)
+    normalized_package = replace_ar_member(original, "data.tar.gz", normalized_tar)
+
+    package_mode = stat.S_IMODE(package.stat().st_mode)
+    temp_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", prefix=f".{package.name}.", dir=package.parent, delete=False
+        ) as output:
+            temp_name = output.name
+            output.write(normalized_package)
+            output.flush()
+            os.fsync(output.fileno())
+        os.chmod(temp_name, package_mode)
+        os.replace(temp_name, package)
+    finally:
+        if temp_name is not None and os.path.exists(temp_name):
+            os.unlink(temp_name)
+    return entry_count
+
+
+def octal_mode(value: str) -> int:
+    try:
+        mode = int(value, 8)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(f"invalid octal mode: {value}") from error
+    if not 0 <= mode <= 0o7777:
+        raise argparse.ArgumentTypeError(f"mode is out of range: {value}")
+    return mode
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("ipk", type=Path)
+    parser.add_argument("--uid", type=int, default=0)
+    parser.add_argument("--gid", type=int, default=5000)
+    parser.add_argument("--directory-mode", type=octal_mode, default=0o775)
+    args = parser.parse_args()
+
+    if not args.ipk.is_file():
+        parser.error(f"IPK does not exist: {args.ipk}")
+
+    try:
+        entry_count = normalize_package(
+            args.ipk, args.uid, args.gid, args.directory_mode
+        )
+    except (OSError, ValueError) as error:
+        parser.error(str(error))
+
+    print(
+        f"Normalized {entry_count} data.tar.gz entries in {args.ipk}: "
+        f"uid={args.uid}, gid={args.gid}, directories={args.directory_mode:04o}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

Cobalt runs as **gid 5000** on the TV. `ares-package` takes uid/gid straight
from the filesystem — `lib/package.js` only clamps out-of-range values — and
exposes no option to override them, so a package carries the build user's
ownership and webOS keeps it at install time.

webOS resets app directories to `775` on reboot. `775` grants write to the
owner and the group and leaves *other* at `r-x`. With the payload owned
`1001:1001` the app is neither, so it falls through to *other* and loses write
access to `content/`, `storage/` and `tmp/`.

Cobalt writes localStorage atomically — temp file, then `rename()` — and
`rename()` needs write permission on the **directory**, not the file. So
settings and sign-in silently stop persisting after the first reboot. This is
the mechanism behind #66 ("Settings Won't Save When App Closes").

## What this changes

`scripts/normalize-ipk-ownership.py` already exists for exactly this — it was
added in #70 and the starterless path runs it — but it never landed on `main`,
and the standard package target never called it. The two packages built on the
same day still disagree:

```
v2.0.2-beta (starterless):  0/5000      dirs 775     ← runs the normalizer
v1.2.4      (standard):     1001/1001   dirs 0777    ← never did
```

Reproducible on the published release, no TV required:

```console
$ tar tvzf data.tar.gz | head -3
drwxrwxrwx 1001/1001  0  usr/
drwxrwxrwx 1001/1001  0  usr/palm/
drwxrwxrwx 1001/1001  0  usr/palm/applications/
```

So this PR carries the script over from `starterless-cobalt-playback`
**unchanged** and calls it from the package target, just before
`verify-ipk-container.py`. The knobs are overridable (`IPK_OWNER_UID`,
`IPK_OWNER_GID`, `IPK_DIR_MODE`), and CI gains a `--help` smoke check next to
the existing `verify-pjtr-starter.py` one.

Normalizing the built IPK rather than the staged tree is what the starterless
path already does, and it is also what the build constrains us to:
`docker-make.%` runs as `-u $(id -u):$(id -g)`, so the tree cannot be chowned
to uid 0 before packaging without pulling `fakeroot` into the build image.

## Verification

Against the released `youtube.leanback.v4_1.2.4_arm.ipk`:

| Check | Result |
|---|---|
| Ownership | 466/466 entries → `0/5000` |
| Directory modes | 92 directories `0777` → `0775` |
| Executables | `cobalt`, `crashpad_handler`, `manifest.json` stay `0755` |
| Outer container | `debian-binary` and `control.tar.gz` byte identical |
| Payload contents | `diff -r --no-dereference` clean across all 466 members |
| Container | still passes `verify-ipk-container.py` |
| Idempotence | second run reproduces the same md5 |

The resulting ownership matches what I have been running on an LG C5
(`OLED77C56LA`, webOS 10.3.1) via a local repack, where persistence is
confirmed working: the storage file resumed being rewritten as soon as the
ownership was corrected, having previously frozen across many launches.

I could not build the standard IPK end to end here, since that needs the
private images repo — this is verified by running the normalizer against the
released artifact.
