### PR TITLE
Prevent SponsorBlock end skips from repeating videos

### DIFF
--- a/webapp/src/sponsorblock-skip-target.mjs
+++ b/webapp/src/sponsorblock-skip-target.mjs
@@ -1,0 +1,21 @@
+const TERMINAL_SEGMENT_TOLERANCE_SECONDS = 1;
+const NATURAL_END_TAIL_SECONDS = 0.25;
+
+export function getSponsorBlockSkipTarget(
+  segmentEnd,
+  duration,
+  currentTime = 0
+) {
+  if (!Number.isFinite(segmentEnd)) return null;
+
+  if (!Number.isFinite(duration) || duration <= 0) {
+    return segmentEnd;
+  }
+
+  if (segmentEnd >= duration - TERMINAL_SEGMENT_TOLERANCE_SECONDS) {
+    const naturalEndTarget = Math.max(0, duration - NATURAL_END_TAIL_SECONDS);
+    return currentTime < naturalEndTarget ? naturalEndTarget : null;
+  }
+
+  return Math.min(segmentEnd, duration);
+}

--- a/webapp/src/sponsorblock.js
+++ b/webapp/src/sponsorblock.js
@@ -6,6 +6,7 @@ import {
   sponsorBlockCategoryConfig as categoryConfig,
   sponsorBlockCategoryColors as categoryColors
 } from './sponsorblock-categories.js';
+import { getSponsorBlockSkipTarget } from './sponsorblock-skip-target.mjs';
 
 const sponsorblockAPI = 'https://sponsor.ajay.app/api';
 const markerAttribute = 'data-ytaf-sponsorblock-marker';
@@ -782,8 +783,12 @@ class SponsorBlockController {
     if (this.skipped[key]) return;
     this.skipped[key] = true;
 
-    const skipTo = Math.min(activeSegment.segment[1] + 0.01, this.video.duration || activeSegment.segment[1]);
-    this.video.currentTime = skipTo;
+    const skipTo = getSponsorBlockSkipTarget(
+      activeSegment.segment[1] + 0.01,
+      this.video.duration,
+      currentTime
+    );
+    if (skipTo !== null) this.video.currentTime = skipTo;
     this.lastSkipText = `${activeSegment.category} ${activeSegment.segment[0].toFixed(
       1
     )}-${activeSegment.segment[1].toFixed(1)}`;
@@ -822,7 +827,16 @@ class SponsorBlockController {
       this.lastSkipText = `${activeSegments[0].category} ${start.toFixed(
         1
       )}-${skipEnd.toFixed(1)}`;
-      this.video.currentTime = skipEnd;
+      activeSegments.forEach((activeSegment) => {
+        const key = `${activeSegment.category}:${activeSegment.segment[0]}:${activeSegment.segment[1]}`;
+        this.skipped[key] = true;
+      });
+      const skipTo = getSponsorBlockSkipTarget(
+        skipEnd,
+        this.video.duration,
+        this.video.currentTime
+      );
+      if (skipTo !== null) this.video.currentTime = skipTo;
       showNotification(`${text('sponsorBlock', 'skipping')} ${categoryLabel(activeSegments[0].category)}`, 1600, 'yellow');
       this.scheduleSkip();
     }, delay);
@@ -841,6 +855,7 @@ class SponsorBlockController {
       .filter(
         (segment) =>
           this.isSegmentSkippable(segment) &&
+          !this.skipped[`${segment.category}:${segment.segment[0]}:${segment.segment[1]}`] &&
           segment.segment[0] > currentTime - 0.3 &&
           segment.segment[1] > currentTime - 0.3
       )
@@ -854,6 +869,7 @@ class SponsorBlockController {
       .filter(
         (segment) =>
           this.isSegmentSkippable(segment) &&
+          !this.skipped[`${segment.category}:${segment.segment[0]}:${segment.segment[1]}`] &&
           segment.segment[0] <= currentTime + 0.3 &&
           segment.segment[1] > currentTime - 0.3
       )

--- a/webapp/test/sponsorblock-end-skip.test.mjs
+++ b/webapp/test/sponsorblock-end-skip.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getSponsorBlockSkipTarget } from '../src/sponsorblock-skip-target.mjs';
+
+test('a terminal SponsorBlock segment leaves a short tail for natural ended', () => {
+  assert.equal(getSponsorBlockSkipTarget(120, 120, 90), 119.75);
+  assert.equal(getSponsorBlockSkipTarget(119.8, 120, 90), 119.75);
+});
+
+test('a terminal skip never seeks backwards while already in the end tail', () => {
+  assert.equal(getSponsorBlockSkipTarget(120, 120, 119.9), null);
+});
+
+test('ordinary and unknown-duration skips retain their endpoint', () => {
+  assert.equal(getSponsorBlockSkipTarget(45, 120, 20), 45);
+  assert.equal(getSponsorBlockSkipTarget(45, Number.NaN, 20), 45);
+});


### PR DESCRIPTION
## Summary

- avoid seeking exactly to or beyond media duration for terminal SponsorBlock segments
- leave a short playback tail so the native `ended` transition occurs normally
- record timer-driven skips as completed to prevent the same terminal segment from being scheduled repeatedly
- retain existing behavior for ordinary and unknown-duration segment skips

## Testing

- `npm test`
- added coverage for terminal, already-in-tail, ordinary, and unknown-duration skip targets
- production webpack bundle completed successfully in the combined test build