### PR TITLE
Fix configured startup page after preload relaunch

### DIFF
--- a/webapp/src/adblock-main.js
+++ b/webapp/src/adblock-main.js
@@ -6,7 +6,7 @@ import './domrect-polyfill';
 import './json-stringify-hook';
 import './ui.js';
 
-import { handleInitialLaunch, handleLaunch, waitForChildAdd } from './utils';
+import { handleInitialLaunch, handleRelaunch, waitForChildAdd } from './utils';
 import { configRead } from './config.js';
 import { userScriptStartUI } from './ui.js';
 import { userScriptStartSponsoredQrCodeUI } from './sponsored-qr-code-ui.js';
@@ -25,7 +25,7 @@ document.addEventListener(
   (evt) => {
     console.info('RELAUNCH:', evt, window.launchParams);
     resetAutoLogin();
-    handleLaunch(evt.detail);
+    handleRelaunch(evt.detail);
   },
   true
 );

--- a/webapp/src/utils.js
+++ b/webapp/src/utils.js
@@ -13,8 +13,11 @@ const STARTUP_PAGE_ENDPOINTS = {
   library: { browseId: 'FElibrary' }
 };
 const STARTUP_PAGE_RETRY_INTERVAL_MS = 250;
-const STARTUP_PAGE_MAX_ATTEMPTS = 80;
+// A cold TV boot can take considerably longer than an ordinary app launch to
+// restore the account and populate the guide. Keep retrying for two minutes.
+const STARTUP_PAGE_MAX_ATTEMPTS = 480;
 let startupPageApplied = false;
+let startupPageRun = 0;
 
 export function getStartupPageUrl(page = configRead('startupPage')) {
   const browseId = STARTUP_PAGE_ENDPOINTS[page] &&
@@ -91,8 +94,25 @@ export function handleLaunch(params) {
   window.location.href = href;
 }
 
-export function handleInitialLaunch() {
-  const params = extractLaunchParams();
+export function handleRelaunch(params = {}) {
+  startupPageRun += 1;
+  startupPageApplied = false;
+
+  if (params.target !== undefined || params.contentTarget !== undefined) {
+    handleLaunch(params);
+    return;
+  }
+
+  if (configRead('startupPage') === 'home') {
+    handleLaunch(params);
+    return;
+  }
+
+  handleInitialLaunch(params);
+}
+
+export function handleInitialLaunch(launchParams) {
+  const params = launchParams || extractLaunchParams();
   if (params.target !== undefined || params.contentTarget !== undefined) {
     return;
   }
@@ -101,8 +121,10 @@ export function handleInitialLaunch() {
   const startupEndpoint = STARTUP_PAGE_ENDPOINTS[page];
   if (!startupEndpoint || startupPageApplied) return;
 
+  const run = ++startupPageRun;
   let attempts = 0;
   const applyStartupPage = () => {
+    if (run !== startupPageRun || startupPageApplied) return;
     attempts += 1;
 
     const renderers = document.querySelectorAll('ytlr-guide-entry-renderer');

--- a/webapp/test/startup-page-cold-boot.test.mjs
+++ b/webapp/test/startup-page-cold-boot.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const source = readFileSync(
+  new URL('../src/utils.js', import.meta.url),
+  'utf8'
+);
+
+test('startup-page retries cover a two-minute cold-boot window', () => {
+  const interval = Number(
+    source.match(/STARTUP_PAGE_RETRY_INTERVAL_MS\s*=\s*(\d+)/)?.[1]
+  );
+  const attempts = Number(
+    source.match(/STARTUP_PAGE_MAX_ATTEMPTS\s*=\s*(\d+)/)?.[1]
+  );
+
+  assert.equal(interval, 250);
+  assert.ok(attempts * interval >= 120_000);
+});
+
+test('an empty webOS relaunch reapplies a non-home startup page', () => {
+  const relaunchBody = source.slice(
+    source.indexOf('export function handleRelaunch'),
+    source.indexOf('\nexport function handleInitialLaunch')
+  );
+
+  assert.match(relaunchBody, /startupPageApplied\s*=\s*false/);
+  assert.match(relaunchBody, /handleInitialLaunch\(params\)/);
+  assert.match(
+    relaunchBody,
+    /params\.target\s*!==\s*undefined[\s\S]*params\.contentTarget\s*!==\s*undefined[\s\S]*handleLaunch\(params\)/
+  );
+});


### PR DESCRIPTION
## Summary

- reapply the configured startup page when opening an app instance created by webOS preload
- preserve content-target and voice/deep-link relaunch behavior
- extend guide discovery to cover slow cold-boot account and navigation initialization
- cancel superseded startup retries so preload and foreground launch attempts cannot both select a page

## Testing

- `npm test`
- production webpack bundle completed successfully in the combined test build
- confirmed on a physical LG webOS TV that the configured startup page loads after reboot